### PR TITLE
[PC-300] 약관 디테일 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,6 @@ android {
         buildConfigField("String", "KAKAO_APP_KEY", "\"${localProperties["KAKAO_APP_KEY"]}\"")
     }
 
-    packaging { resources { excludes += "/META-INF/*" } }
-
     buildTypes {
         release {
             signingConfig = signingConfigs.getByName("debug")

--- a/build-logic/src/main/java/com/puzzle/build/logic/KotlinAndroid.kt
+++ b/build-logic/src/main/java/com/puzzle/build/logic/KotlinAndroid.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureKotlinAndroid() {
     pluginManager.apply("org.jetbrains.kotlin.android")
-    pluginManager.apply("org.jetbrains.kotlin.plugin.serialization")
 
     androidExtension.apply {
         compileSdk = 35

--- a/build-logic/src/main/java/com/puzzle/build/logic/configure/AndroidComposes.kt
+++ b/build-logic/src/main/java/com/puzzle/build/logic/configure/AndroidComposes.kt
@@ -8,6 +8,7 @@ import org.gradle.kotlin.dsl.dependencies
 internal fun Project.configureAndroidCompose() {
     with(plugins) {
         apply("org.jetbrains.kotlin.plugin.compose")
+        apply("org.jetbrains.kotlin.plugin.serialization")
     }
 
     val libs = extensions.libs
@@ -28,7 +29,7 @@ internal fun Project.configureAndroidCompose() {
             add("implementation", libs.findLibrary("androidx.compose.material3").get())
             add("implementation", libs.findLibrary("androidx.compose.ui").get())
             add("implementation", libs.findLibrary("androidx.compose.ui.tooling.preview").get())
-            add("debugImplementation", libs.findLibrary("androidx.compose.ui.tooling").get())
+            add("implementation", libs.findLibrary("androidx.compose.ui.tooling").get())
         }
     }
 }

--- a/build-logic/src/main/java/com/puzzle/build/logic/configure/AndroidComposes.kt
+++ b/build-logic/src/main/java/com/puzzle/build/logic/configure/AndroidComposes.kt
@@ -29,7 +29,7 @@ internal fun Project.configureAndroidCompose() {
             add("implementation", libs.findLibrary("androidx.compose.material3").get())
             add("implementation", libs.findLibrary("androidx.compose.ui").get())
             add("implementation", libs.findLibrary("androidx.compose.ui.tooling.preview").get())
-            add("implementation", libs.findLibrary("androidx.compose.ui.tooling").get())
+            add("debugImplementation", libs.findLibrary("androidx.compose.ui.tooling").get())
         }
     }
 }

--- a/core/data/src/main/java/com/puzzle/data/repository/TermsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/puzzle/data/repository/TermsRepositoryImpl.kt
@@ -28,7 +28,7 @@ class TermsRepositoryImpl @Inject constructor(
             )
         }
 
-        localTermDataSource.clearAndInsertTerms(termsEntity)
+        localTermDataSource.replaceTerms(termsEntity)
     }
 
     override suspend fun getTerms(): Result<List<Term>> = runCatching {

--- a/core/data/src/main/java/com/puzzle/data/repository/TermsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/puzzle/data/repository/TermsRepositoryImpl.kt
@@ -32,7 +32,7 @@ class TermsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getTerms(): Result<List<Term>> = runCatching {
-        localTermDataSource.getTerms()
+        localTermDataSource.retrieveTerms()
             .map { it.toDomain() }
     }
 }

--- a/core/data/src/main/java/com/puzzle/data/repository/TermsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/puzzle/data/repository/TermsRepositoryImpl.kt
@@ -16,11 +16,11 @@ class TermsRepositoryImpl @Inject constructor(
         val terms = termDataSource.loadTerms()
             .getOrThrow()
             .toDomain()
-            .filter { it.termId != UNKNOWN_INT }
+            .filter { it.id != UNKNOWN_INT }
 
         val termsEntity = terms.map {
             TermEntity(
-                id = it.termId,
+                id = it.id,
                 title = it.title,
                 content = it.content,
                 required = it.required,

--- a/core/data/src/test/java/com/puzzle/data/repository/TermsRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/puzzle/data/repository/TermsRepositoryImplTest.kt
@@ -48,7 +48,7 @@ class TermsRepositoryImplTest {
 
         coEvery { termDataSource.loadTerms() } returns
                 Result.success(LoadTermsResponse(listOf(invalidTerm, validTerm)))
-        coEvery { localTermDataSource.clearAndInsertTerms(any()) } just Runs
+        coEvery { localTermDataSource.replaceTerms(any()) } just Runs
 
         // when
         val result = termsRepository.loadTerms()
@@ -56,7 +56,7 @@ class TermsRepositoryImplTest {
         // then
         assertTrue(result.isSuccess)
         coVerify(exactly = 1) {
-            localTermDataSource.clearAndInsertTerms(
+            localTermDataSource.replaceTerms(
                 match {
                     it.size == 1 && it.first().id == validTerm.termId
                 }
@@ -85,14 +85,14 @@ class TermsRepositoryImplTest {
         )
 
         coEvery { termDataSource.loadTerms() } returns Result.success(LoadTermsResponse(validTerms))
-        coEvery { localTermDataSource.clearAndInsertTerms(any()) } just Runs
+        coEvery { localTermDataSource.replaceTerms(any()) } just Runs
 
         // when
         termsRepository.loadTerms()
 
         // then
         coVerify(exactly = 1) {
-            localTermDataSource.clearAndInsertTerms(
+            localTermDataSource.replaceTerms(
                 match {
                     it.size == validTerms.size && it.all { entity ->
                         validTerms.any { term ->

--- a/core/database/src/androidTest/java/com/puzzle/database/dao/TermsDaoTest.kt
+++ b/core/database/src/androidTest/java/com/puzzle/database/dao/TermsDaoTest.kt
@@ -80,7 +80,7 @@ class TermsDaoTest {
         val expected = listOf(
             TermEntity(2, "새로운 약관", "새로운 내용", false, "2024-06-01T00:00:00".parseDateTime())
         )
-        termsDao.clearAndInsertTerms(*expected.toTypedArray())
+        termsDao.replaceTerms(*expected.toTypedArray())
         val actual = termsDao.getTerms()
 
         // then

--- a/core/database/src/main/java/com/puzzle/database/dao/TermsDao.kt
+++ b/core/database/src/main/java/com/puzzle/database/dao/TermsDao.kt
@@ -19,7 +19,7 @@ interface TermsDao {
     suspend fun clearTerms()
 
     @Transaction
-    suspend fun clearAndInsertTerms(vararg terms: TermEntity) {
+    suspend fun replaceTerms(vararg terms: TermEntity) {
         clearTerms()
         insertTerms(*terms)
     }

--- a/core/database/src/main/java/com/puzzle/database/model/terms/TermEntity.kt
+++ b/core/database/src/main/java/com/puzzle/database/model/terms/TermEntity.kt
@@ -16,7 +16,7 @@ data class TermEntity(
     @ColumnInfo(name = "start_date") val startDate: LocalDateTime,
 ) {
     fun toDomain() = Term(
-        termId = id,
+        id = id,
         title = title,
         content = content,
         required = required,

--- a/core/database/src/main/java/com/puzzle/database/source/term/LocalTermDataSource.kt
+++ b/core/database/src/main/java/com/puzzle/database/source/term/LocalTermDataSource.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 class LocalTermDataSource @Inject constructor(
     private val termsDao: TermsDao,
 ) {
-    suspend fun getTerms() = termsDao.getTerms()
+    suspend fun retrieveTerms() = termsDao.getTerms()
     suspend fun clearAndInsertTerms(terms: List<TermEntity>) =
         termsDao.clearAndInsertTerms(*terms.toTypedArray())
 }

--- a/core/database/src/main/java/com/puzzle/database/source/term/LocalTermDataSource.kt
+++ b/core/database/src/main/java/com/puzzle/database/source/term/LocalTermDataSource.kt
@@ -10,6 +10,5 @@ class LocalTermDataSource @Inject constructor(
     private val termsDao: TermsDao,
 ) {
     suspend fun retrieveTerms() = termsDao.getTerms()
-    suspend fun clearAndInsertTerms(terms: List<TermEntity>) =
-        termsDao.clearAndInsertTerms(*terms.toTypedArray())
+    suspend fun replaceTerms(terms: List<TermEntity>) = termsDao.replaceTerms(*terms.toTypedArray())
 }

--- a/core/designsystem/src/main/java/com/puzzle/designsystem/component/TopBar.kt
+++ b/core/designsystem/src/main/java/com/puzzle/designsystem/component/TopBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
@@ -30,7 +31,9 @@ fun PieceMainTopBar(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(60.dp),
     ) {
         Text(
             text = title,
@@ -54,7 +57,9 @@ fun PieceSubTopBar(
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(60.dp),
     ) {
         Image(
             painter = painterResource(R.drawable.ic_arrow_left),
@@ -78,7 +83,11 @@ fun PieceSubBackTopBar(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.fillMaxWidth()) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(60.dp),
+    ) {
         Image(
             painter = painterResource(R.drawable.ic_arrow_left),
             contentDescription = "뒤로 가기 버튼",
@@ -105,7 +114,11 @@ fun PieceSubCloseTopBar(
     closeButtonEnabled: Boolean = true,
     contentColor: Color = PieceTheme.colors.black,
 ) {
-    Box(modifier = modifier.fillMaxWidth()) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(60.dp),
+    ) {
         Text(
             text = title,
             style = PieceTheme.typography.headingSSB,
@@ -176,9 +189,7 @@ fun PreviewPieceSubTopBar() {
                     modifier = Modifier.size(32.dp),
                 )
             },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 20.dp),
+            modifier = Modifier.padding(vertical = 20.dp),
         )
     }
 }

--- a/core/designsystem/src/main/java/com/puzzle/designsystem/component/WebView.kt
+++ b/core/designsystem/src/main/java/com/puzzle/designsystem/component/WebView.kt
@@ -1,0 +1,36 @@
+package com.puzzle.designsystem.component
+
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+
+@Composable
+fun PieceWebView(
+    url: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    AndroidView(
+        factory = {
+            webView = WebView(context).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = object : WebViewClient() {}
+                webChromeClient = object : WebChromeClient() {}
+            }
+            webView!!
+        },
+        update = { it.loadUrl(url) },
+        onRelease = { webView?.destroy() },
+        modifier = modifier,
+    )
+}

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!--Term-->
+    <string name="next">다음</string>
+    <string name="agree">동의하기</string>
+    <string name="all_term_agree">약관 전체 동의</string>
+
     <!--Matching-->
     <string name="matching_title">Matching</string>
     <string name="check_the_matching_pieces">매칭 조각을 확인해주세요!</string>

--- a/core/domain/src/main/java/com/puzzle/domain/model/terms/Term.kt
+++ b/core/domain/src/main/java/com/puzzle/domain/model/terms/Term.kt
@@ -3,7 +3,7 @@ package com.puzzle.domain.model.terms
 import java.time.LocalDateTime
 
 data class Term(
-    val termId: Int,
+    val id: Int,
     val title: String,
     val content: String,
     val required: Boolean,

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("piece.android.library")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {

--- a/core/network/src/main/java/com/puzzle/network/model/terms/LoadTermsResponse.kt
+++ b/core/network/src/main/java/com/puzzle/network/model/terms/LoadTermsResponse.kt
@@ -23,7 +23,7 @@ data class TermResponse(
     val startDate: String?,
 ) {
     fun toDomain(): Term = Term(
-        termId = termId ?: UNKNOWN_INT,
+        id = termId ?: UNKNOWN_INT,
         title = title ?: UNKNOWN_STRING,
         content = content ?: UNKNOWN_STRING,
         required = required ?: false,

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
@@ -1,8 +1,23 @@
 package com.puzzle.auth.graph.registration
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.puzzle.designsystem.component.PieceSubBackTopBar
 
 @Composable
-internal fun RegistrationDetailScreen() {
-
+internal fun RegistrationDetailScreen(
+    termTitle: String,
+    onBackClick: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        PieceSubBackTopBar(
+            title = termTitle,
+            onBackClick = onBackClick,
+            modifier = Modifier
+        )
+    }
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
@@ -1,13 +1,22 @@
 package com.puzzle.auth.graph.registration
 
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import com.puzzle.designsystem.component.PieceSolidButton
 import com.puzzle.designsystem.component.PieceSubBackTopBar
 import com.puzzle.domain.model.terms.Term
@@ -18,6 +27,8 @@ internal fun RegistrationDetailScreen(
     onBackClick: () -> Unit,
     onAgreeClick: () -> Unit,
 ) {
+    BackHandler { onBackClick() }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -28,7 +39,12 @@ internal fun RegistrationDetailScreen(
             onBackClick = onBackClick,
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        PieceWebView(
+            url = term.content,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        )
 
         PieceSolidButton(
             label = "동의하기",
@@ -38,4 +54,27 @@ internal fun RegistrationDetailScreen(
                 .padding(top = 12.dp, bottom = 10.dp),
         )
     }
+}
+
+@Composable
+internal fun PieceWebView(
+    url: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    AndroidView(
+        factory = {
+            webView = WebView(context).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = object : WebViewClient() {}
+                webChromeClient = object : WebChromeClient() {}
+            }
+            webView!!
+        },
+        update = { it.loadUrl(url) },
+        onRelease = { webView?.destroy() },
+        modifier = modifier,
+    )
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
@@ -1,23 +1,41 @@
 package com.puzzle.auth.graph.registration
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.puzzle.designsystem.component.PieceSolidButton
 import com.puzzle.designsystem.component.PieceSubBackTopBar
+import com.puzzle.domain.model.terms.Term
 
 @Composable
 internal fun RegistrationDetailScreen(
-    termTitle: String,
+    term: Term,
     onBackClick: () -> Unit,
+    onAgreeClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp),
+    ) {
         PieceSubBackTopBar(
-            title = termTitle,
+            title = term.title,
             onBackClick = onBackClick,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        PieceSolidButton(
+            label = "동의하기",
+            onClick = onAgreeClick,
             modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp, bottom = 10.dp),
         )
     }
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceSolidButton
 import com.puzzle.designsystem.component.PieceSubBackTopBar
 import com.puzzle.designsystem.component.PieceWebView
@@ -39,7 +41,7 @@ internal fun RegistrationDetailScreen(
         )
 
         PieceSolidButton(
-            label = "동의하기",
+            label = stringResource(R.string.agree),
             onClick = onAgreeClick,
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationDetailScreen.kt
@@ -1,24 +1,16 @@
 package com.puzzle.auth.graph.registration
 
-import android.webkit.WebChromeClient
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import com.puzzle.designsystem.component.PieceSolidButton
 import com.puzzle.designsystem.component.PieceSubBackTopBar
+import com.puzzle.designsystem.component.PieceWebView
 import com.puzzle.domain.model.terms.Term
 
 @Composable
@@ -54,27 +46,4 @@ internal fun RegistrationDetailScreen(
                 .padding(top = 12.dp, bottom = 10.dp),
         )
     }
-}
-
-@Composable
-internal fun PieceWebView(
-    url: String,
-    modifier: Modifier = Modifier,
-) {
-    val context = LocalContext.current
-    var webView by remember { mutableStateOf<WebView?>(null) }
-
-    AndroidView(
-        factory = {
-            webView = WebView(context).apply {
-                settings.javaScriptEnabled = true
-                webViewClient = object : WebViewClient() {}
-                webChromeClient = object : WebChromeClient() {}
-            }
-            webView!!
-        },
-        update = { it.loadUrl(url) },
-        onRelease = { webView?.destroy() },
-        modifier = modifier,
-    )
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -54,7 +53,6 @@ private fun RegistrationScreen(
         PieceSubBackTopBar(
             title = "",
             onBackClick = { navigate(NavigationEvent.NavigateUp) },
-            modifier = Modifier.height(60.dp),
         )
 
         Text(

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
@@ -20,6 +21,7 @@ import com.airbnb.mvrx.compose.mavericksViewModel
 import com.puzzle.auth.graph.registration.contract.RegistrationIntent
 import com.puzzle.auth.graph.registration.contract.RegistrationSideEffect
 import com.puzzle.auth.graph.registration.contract.RegistrationState
+import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceCheckList
 import com.puzzle.designsystem.component.PieceSolidButton
 import com.puzzle.designsystem.component.PieceSubBackTopBar
@@ -95,7 +97,7 @@ private fun RegistrationScreen(
 
         PieceCheckList(
             checked = state.allTermsAgreed,
-            label = "약관 전체 동의",
+            label = stringResource(R.string.all_term_agree),
             containerColor = PieceTheme.colors.light3,
             onCheckedChange = checkAllTerms,
             modifier = Modifier
@@ -121,7 +123,7 @@ private fun RegistrationScreen(
         )
 
         PieceSolidButton(
-            label = "다음",
+            label = stringResource(R.string.next),
             onClick = {},
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
@@ -85,7 +85,7 @@ class RegistrationViewModel @AssistedInject constructor(
             val updatedTermsCheckedInfo = termsCheckedInfo.toMutableMap()
 
             terms.forEach { termInfo ->
-                updatedTermsCheckedInfo[termInfo.termId] = true
+                updatedTermsCheckedInfo[termInfo.id] = true
             }
 
             copy(termsCheckedInfo = updatedTermsCheckedInfo)

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
@@ -1,6 +1,5 @@
 package com.puzzle.auth.graph.registration
 
-import android.util.Log
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
@@ -67,7 +66,6 @@ class RegistrationViewModel @AssistedInject constructor(
 
     private fun fetchTerms() = viewModelScope.launch {
         termsRepository.getTerms().onSuccess {
-            Log.d("test", it.toString())
             setState { copy(terms = it) }
         }.onFailure { errorHelper.sendError(it) }
     }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
@@ -1,5 +1,6 @@
 package com.puzzle.auth.graph.registration
 
+import android.util.Log
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
@@ -66,6 +67,7 @@ class RegistrationViewModel @AssistedInject constructor(
 
     private fun fetchTerms() = viewModelScope.launch {
         termsRepository.getTerms().onSuccess {
+            Log.d("test", it.toString())
             setState { copy(terms = it) }
         }.onFailure { errorHelper.sendError(it) }
     }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/RegistrationViewModel.kt
@@ -71,25 +71,21 @@ class RegistrationViewModel @AssistedInject constructor(
     }
 
     private fun checkTerm(termId: Int) = setState {
-        val updatedTermsCheckedInfo = termsCheckedInfo.toMutableMap().apply {
-            this[termId] = !(this[termId] ?: false)
-        }
+        val updatedTermsCheckedInfo = termsCheckedInfo.toMutableMap()
+            .apply { this[termId] = !(this[termId] ?: false) }
+            .toMap()
 
         copy(termsCheckedInfo = updatedTermsCheckedInfo)
     }
 
     private fun checkAllTerms() = setState {
-        if (allTermsAgreed) {
-            copy(termsCheckedInfo = mutableMapOf())
+        val updatedTermsCheckedInfo = if (allTermsAgreed) {
+            emptyMap()
         } else {
-            val updatedTermsCheckedInfo = termsCheckedInfo.toMutableMap()
-
-            terms.forEach { termInfo ->
-                updatedTermsCheckedInfo[termInfo.id] = true
-            }
-
-            copy(termsCheckedInfo = updatedTermsCheckedInfo)
+            terms.associate { termInfo -> termInfo.id to true }
         }
+
+        copy(termsCheckedInfo = updatedTermsCheckedInfo)
     }
 
     @AssistedFactory

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/contract/RegistrationState.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/contract/RegistrationState.kt
@@ -5,7 +5,7 @@ import com.puzzle.domain.model.terms.Term
 
 data class RegistrationState(
     val terms: List<Term> = emptyList(),
-    val termsCheckedInfo: MutableMap<Int, Boolean> = mutableMapOf(),
+    val termsCheckedInfo: Map<Int, Boolean> = emptyMap(),
 ) : MavericksState {
     val allTermsAgreed = terms.all { termsCheckedInfo.getOrDefault(it.id, false) }
 

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/contract/RegistrationState.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/contract/RegistrationState.kt
@@ -7,5 +7,17 @@ data class RegistrationState(
     val terms: List<Term> = emptyList(),
     val termsCheckedInfo: MutableMap<Int, Boolean> = mutableMapOf(),
 ) : MavericksState {
-    val allTermsAgreed = terms.all { termsCheckedInfo.getOrDefault(it.termId, false) }
+    val allTermsAgreed = terms.all { termsCheckedInfo.getOrDefault(it.id, false) }
+
+    enum class RegistrationPage() {
+        TermPage,
+        TermDetailPage,
+        AccessRightsPage,
+        AvoidAcquaintancesPage,
+        SignUpCompleted;
+
+        companion object {
+
+        }
+    }
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/registration/ui/RegistrationDetailScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/registration/ui/RegistrationDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.puzzle.auth.graph.registration
+package com.puzzle.auth.graph.registration.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/MatchingDetailRoute.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/MatchingDetailRoute.kt
@@ -37,10 +37,10 @@ import com.puzzle.designsystem.component.PieceImageDialog
 import com.puzzle.designsystem.component.PieceRoundingButton
 import com.puzzle.designsystem.component.PieceSubCloseTopBar
 import com.puzzle.designsystem.foundation.PieceTheme
-import com.puzzle.matching.common.constant.DialogType
-import com.puzzle.matching.common.ui.BasicInfoBody
-import com.puzzle.matching.common.ui.ValuePickBody
-import com.puzzle.matching.common.ui.ValueTalkBody
+import com.puzzle.matching.graph.detail.common.constant.DialogType
+import com.puzzle.matching.graph.detail.common.ui.BasicInfoBody
+import com.puzzle.matching.graph.detail.common.ui.ValuePickBody
+import com.puzzle.matching.graph.detail.common.ui.ValueTalkBody
 import com.puzzle.matching.graph.detail.contract.MatchingDetailIntent
 import com.puzzle.matching.graph.detail.contract.MatchingDetailState
 import com.puzzle.matching.graph.detail.contract.MatchingDetailState.MatchingDetailPage
@@ -149,7 +149,7 @@ private fun MatchingDetailScreen(
         modifier = modifier
             .fillMaxSize()
             .then(
-                if (state.currentPage != MatchingDetailPage.BasicInfoState) {
+                if (state.currentPage != MatchingDetailPage.BasicInfoPage) {
                     Modifier.background(PieceTheme.colors.light3)
                 } else {
                     Modifier
@@ -184,7 +184,7 @@ private fun MatchingDetailScreen(
                 .height(topBarHeight)
                 .align(Alignment.TopCenter)
                 .let {
-                    if (state.currentPage != MatchingDetailPage.BasicInfoState) {
+                    if (state.currentPage != MatchingDetailPage.BasicInfoPage) {
                         it.background(PieceTheme.colors.white)
                     } else {
                         it
@@ -243,7 +243,7 @@ private fun MatchingDetailContent(
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         when (state.currentPage) {
-            MatchingDetailState.MatchingDetailPage.BasicInfoState ->
+            MatchingDetailState.MatchingDetailPage.BasicInfoPage ->
                 BasicInfoBody(
                     nickName = state.nickName,
                     selfDescription = state.selfDescription,
@@ -258,7 +258,7 @@ private fun MatchingDetailContent(
                     modifier = Modifier.padding(horizontal = 20.dp),
                 )
 
-            MatchingDetailState.MatchingDetailPage.ValueTalkState ->
+            MatchingDetailState.MatchingDetailPage.ValueTalkPage ->
                 ValueTalkBody(
                     nickName = state.nickName,
                     selfDescription = state.selfDescription,
@@ -266,7 +266,7 @@ private fun MatchingDetailContent(
                     onMoreClick = onMoreClick,
                 )
 
-            MatchingDetailState.MatchingDetailPage.ValuePickState ->
+            MatchingDetailState.MatchingDetailPage.ValuePickPage ->
                 ValuePickBody(
                     nickName = state.nickName,
                     selfDescription = state.selfDescription,
@@ -290,7 +290,7 @@ private fun MatchingDetailBottomBar(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier,
     ) {
-        if (currentPage == MatchingDetailPage.ValuePickState) {
+        if (currentPage == MatchingDetailPage.ValuePickPage) {
             Image(
                 painter = painterResource(id = R.drawable.ic_profile_image),
                 contentDescription = "이전 페이지 버튼",
@@ -304,7 +304,7 @@ private fun MatchingDetailBottomBar(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (currentPage == MatchingDetailPage.BasicInfoState) {
+        if (currentPage == MatchingDetailPage.BasicInfoPage) {
             Image(
                 painter = painterResource(id = R.drawable.ic_left_disable),
                 contentDescription = "이전 페이지 버튼",
@@ -325,7 +325,7 @@ private fun MatchingDetailBottomBar(
 
         Spacer(modifier = Modifier.width(8.dp))
 
-        if (currentPage == MatchingDetailPage.ValuePickState) {
+        if (currentPage == MatchingDetailPage.ValuePickPage) {
             PieceRoundingButton(
                 label = stringResource(R.string.valuepick_bottom_bar_label),
                 onClick = onAcceptClick,
@@ -366,7 +366,7 @@ private fun MatchingDetailScreenPreview() {
 private fun BottomNavigationOnBasicInfoStatePreview() {
     PieceTheme {
         MatchingDetailBottomBar(
-            currentPage = MatchingDetailPage.BasicInfoState,
+            currentPage = MatchingDetailPage.BasicInfoPage,
             {},
             {},
             {},
@@ -380,7 +380,7 @@ private fun BottomNavigationOnBasicInfoStatePreview() {
 private fun BottomNavigationOnValueTalkStatePreview() {
     PieceTheme {
         MatchingDetailBottomBar(
-            currentPage = MatchingDetailPage.ValueTalkState,
+            currentPage = MatchingDetailPage.ValueTalkPage,
             {},
             {},
             {},
@@ -394,7 +394,7 @@ private fun BottomNavigationOnValueTalkStatePreview() {
 private fun BottomNavigationOnValuePickStatePreview() {
     PieceTheme {
         MatchingDetailBottomBar(
-            currentPage = MatchingDetailPage.ValuePickState,
+            currentPage = MatchingDetailPage.ValuePickPage,
             {},
             {},
             {},

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/component/BasicInfoHeader.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/component/BasicInfoHeader.kt
@@ -1,4 +1,4 @@
-package com.puzzle.matching.common.component
+package com.puzzle.matching.graph.detail.common.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/constant/DialogType.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/constant/DialogType.kt
@@ -1,4 +1,4 @@
-package com.puzzle.matching.common.constant
+package com.puzzle.matching.graph.detail.common.constant
 
 enum class DialogType {
     ACCEPT_MATCHING,

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/ui/BasicInfoBody.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/ui/BasicInfoBody.kt
@@ -1,4 +1,4 @@
-package com.puzzle.matching.common.ui
+package com.puzzle.matching.graph.detail.common.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -21,7 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.foundation.PieceTheme
-import com.puzzle.matching.common.component.BasicInfoHeader
+import com.puzzle.matching.graph.detail.common.component.BasicInfoHeader
 
 @Composable
 internal fun BasicInfoBody(

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/ui/ValuePickBody.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/ui/ValuePickBody.kt
@@ -1,4 +1,4 @@
-package com.puzzle.matching.common.ui
+package com.puzzle.matching.graph.detail.common.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -45,7 +45,7 @@ import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceSubButton
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.domain.model.matching.ValuePick
-import com.puzzle.matching.common.component.BasicInfoHeader
+import com.puzzle.matching.graph.detail.common.component.BasicInfoHeader
 
 @Composable
 internal fun ValuePickBody(

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/ui/ValueTalkBody.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/common/ui/ValueTalkBody.kt
@@ -1,4 +1,4 @@
-package com.puzzle.matching.common.ui
+package com.puzzle.matching.graph.detail.common.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -32,7 +32,7 @@ import com.puzzle.common.ui.CollapsingHeaderNestedScrollConnection
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.domain.model.matching.ValueTalk
-import com.puzzle.matching.common.component.BasicInfoHeader
+import com.puzzle.matching.graph.detail.common.component.BasicInfoHeader
 
 @Composable
 internal fun ValueTalkBody(

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/contract/MatchingDetailState.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/contract/MatchingDetailState.kt
@@ -6,7 +6,7 @@ import com.puzzle.domain.model.matching.ValueTalk
 
 data class MatchingDetailState(
     val isLoading: Boolean = false,
-    val currentPage: MatchingDetailPage = MatchingDetailPage.BasicInfoState,
+    val currentPage: MatchingDetailPage = MatchingDetailPage.BasicInfoPage,
     // BasicInfoState
     val selfDescription: String = "",
     val nickName: String = "",
@@ -22,24 +22,24 @@ data class MatchingDetailState(
 ) : MavericksState {
 
     enum class MatchingDetailPage(val title: String) {
-        BasicInfoState(title = ""),
-        ValueTalkState(title = "가치관 Talk"),
-        ValuePickState(title = "가치관 Pick");
+        BasicInfoPage(title = ""),
+        ValueTalkPage(title = "가치관 Talk"),
+        ValuePickPage(title = "가치관 Pick");
 
         companion object {
             fun getNextPage(currentPage: MatchingDetailPage): MatchingDetailPage {
                 return when (currentPage) {
-                    BasicInfoState -> ValueTalkState
-                    ValueTalkState -> ValuePickState
-                    ValuePickState -> ValuePickState
+                    BasicInfoPage -> ValueTalkPage
+                    ValueTalkPage -> ValuePickPage
+                    ValuePickPage -> ValuePickPage
                 }
             }
 
             fun getPreviousPage(currentPage: MatchingDetailPage): MatchingDetailPage {
                 return when (currentPage) {
-                    BasicInfoState -> BasicInfoState
-                    ValueTalkState -> BasicInfoState
-                    ValuePickState -> ValueTalkState
+                    BasicInfoPage -> BasicInfoPage
+                    ValueTalkPage -> BasicInfoPage
+                    ValuePickPage -> ValueTalkPage
                 }
             }
         }


### PR DESCRIPTION
[PC-300](https://yapp25app3.atlassian.net/browse/PC-300?atlOrigin=eyJpIjoiYTYyMjY3Yjk2Y2NlNDk0NTg3ZTA2MjE5YzI3ZWZkNWYiLCJwIjoiaiJ9)

## 1. ⭐️ 변경된 내용 
- **약관 디테일 화면을 구현하였습니다.**
- **디자인 시스템에서 TopBar의 높이가 60 고정인 것을 확인하여 높이를 60을 고정으로 주었습니다.**
- **약관 상세 페이지를 웹뷰로 뛰우기로 하여서 PieceWebView 컴포넌트를 만들었습니다. 해당 컴포넌트는 Setting 모듈에서도 사용할 예정이라 designSystem으로 올렸습니다.**

## 2. 🖼️ 스크린샷(선택)

https://github.com/user-attachments/assets/4d51682e-b6e0-44db-874c-54a2fa4c238b

## 3. 📌 이 부분은 꼭 봐주세요!

제가 웹뷰를 잘 모르는데, 혹시 웹뷰 페이지가 로딩될 때 까지 상단 탑바까지 랜더링이 안되는데 이유를 아시나요 ...?

여러가지 삽질도 해보고 gpt한테 물어보기도 했는데 잘 모르겠네요 ㅠㅠㅠ

웹뷰 페이지가 랜딩이 다 되어야지만 탑바가 같이 랜더링 되어요 ㅠㅜㅠㅠㅠ

[PC-300]: https://yapp25app3.atlassian.net/browse/PC-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ