### PR TITLE
[PC-254] 코루틴 유틸함수 추가 및 LoginScreen 불필요한 Spacer 제거

### DIFF
--- a/core/common-ui/src/main/java/com/puzzle/common/ui/CoroutineUtil.kt
+++ b/core/common-ui/src/main/java/com/puzzle/common/ui/CoroutineUtil.kt
@@ -1,0 +1,14 @@
+package com.puzzle.common.ui
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+fun LifecycleOwner.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
+    lifecycleScope.launch {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
+    }
+}

--- a/core/designsystem/src/main/java/com/puzzle/designsystem/component/Button.kt
+++ b/core/designsystem/src/main/java/com/puzzle/designsystem/component/Button.kt
@@ -158,6 +158,7 @@ fun PieceLoginButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    border: BorderStroke? = null,
     containerColor: Color = PieceTheme.colors.primaryDefault,
     labelColor: Color = PieceTheme.colors.black
 ) {
@@ -165,6 +166,7 @@ fun PieceLoginButton(
         onClick = onClick,
         enabled = enabled,
         shape = RoundedCornerShape(8.dp),
+        border = border,
         colors = ButtonDefaults.buttonColors(
             containerColor = containerColor,
             contentColor = PieceTheme.colors.white,

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="accept_matching">매칭 수락하기</string>
 
     <!--login-->
+    <string name="login_description">서로의 빈 곳을 채우며 맞물리는 퍼즐처럼.\n서로의 가치관과 마음이 연결되는 순간을 만들어갑니다.</string>
     <string name="kakao_login">카카오로 시작하기</string>
     <string name="google_login">구글로 시작하기</string>
 

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -7,5 +7,6 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.common)
     implementation(libs.kakao.user)
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
@@ -108,13 +108,13 @@ fun LoginScreen(
         Spacer(modifier = Modifier.height(12.dp))
 
         Text(
-            text = "서로의 빈 곳을 채우며 맞물리는 퍼즐처럼.\n서로의 가치관과 마음이 연결되는 순간을 만들어갑니다.",
+            text = stringResource(R.string.login_description),
             style = PieceTheme.typography.bodySM,
             color = PieceTheme.colors.dark3,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 70.dp),
         )
-
-        Spacer(modifier = Modifier.height(70.dp))
 
         Image(
             painter = painterResource(R.drawable.ic_puzzle1),

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
@@ -1,17 +1,15 @@
 package com.puzzle.auth.graph.login
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -85,12 +83,8 @@ fun LoginScreen(
         PieceSubCloseTopBar(
             title = "",
             onCloseClick = { },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 14.dp),
+            modifier = Modifier.fillMaxWidth(),
         )
-
-        Spacer(modifier = Modifier.height(20.dp))
 
         Text(
             text = buildAnnotatedString {
@@ -102,10 +96,10 @@ fun LoginScreen(
             },
             style = PieceTheme.typography.headingLSB,
             color = PieceTheme.colors.black,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 20.dp, bottom = 12.dp),
         )
-
-        Spacer(modifier = Modifier.height(12.dp))
 
         Text(
             text = stringResource(R.string.login_description),
@@ -129,28 +123,24 @@ fun LoginScreen(
         PieceLoginButton(
             label = stringResource(R.string.kakao_login),
             imageId = R.drawable.ic_kakao_login,
-            onClick = {},
+            onClick = loginKakao,
             containerColor = Color(0xFFFFE812),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         )
-
-        Spacer(modifier = Modifier.height(10.dp))
 
         PieceLoginButton(
             label = stringResource(R.string.google_login),
             imageId = R.drawable.ic_google_login,
             onClick = {},
             containerColor = PieceTheme.colors.white,
+            border = BorderStroke(
+                width = 1.dp,
+                color = PieceTheme.colors.light1,
+            ),
             modifier = Modifier
                 .fillMaxWidth()
-                .border(
-                    width = 1.dp,
-                    color = PieceTheme.colors.light1,
-                    shape = RoundedCornerShape(8.dp)
-                ),
+                .padding(vertical = 10.dp),
         )
-
-        Spacer(modifier = Modifier.height(10.dp))
     }
 }
 

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginViewModel.kt
@@ -24,8 +24,8 @@ class LoginViewModel @AssistedInject constructor(
 ) : MavericksViewModel<LoginState>(initialState) {
     private val intents = Channel<LoginIntent>(BUFFERED)
 
-    private val _sideEffect = Channel<LoginSideEffect>(BUFFERED)
-    val sideEffect = _sideEffect.receiveAsFlow()
+    private val _sideEffects = Channel<LoginSideEffect>(BUFFERED)
+    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         intents.receiveAsFlow()
@@ -43,10 +43,8 @@ class LoginViewModel @AssistedInject constructor(
         }
     }
 
-    private fun handleSideEffect(sideEffect: LoginSideEffect) {
-        when (sideEffect) {
-            else -> Unit
-        }
+    internal fun onSideEffect(sideEffect: LoginSideEffect) = viewModelScope.launch {
+        _sideEffects.send(sideEffect)
     }
 
     @AssistedFactory

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/contract/LoginSideEffect.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/contract/LoginSideEffect.kt
@@ -1,3 +1,5 @@
 package com.puzzle.auth.graph.login.contract
 
-sealed class LoginSideEffect
+sealed class LoginSideEffect {
+    data object LoginKakao : LoginSideEffect()
+}

--- a/presentation/src/main/java/com/puzzle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/puzzle/presentation/MainActivity.kt
@@ -9,12 +9,11 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.core.view.WindowCompat
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.puzzle.common.event.PieceEvent
+import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.navigation.MatchingGraph
 import com.puzzle.navigation.NavigationEvent
@@ -42,7 +41,7 @@ class MainActivity : ComponentActivity() {
                 snackBarHostState = remember { SnackbarHostState() }
 
                 LaunchedEffect(Unit) {
-                    repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    repeatOnStarted {
                         launch {
                             navigationHelper.navigationFlow.collect { event ->
                                 handleNavigationEvent(


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- **코루틴 유틸함수 추가 및 LoginScreen 불필요한 Spacer 제거**

## 2. 📌 이 부분은 꼭 봐주세요!

Padding으로 해결할 수 있는 부분은 최대한 Padding으로 해결하면 좋아요!

`Spacer()`로 하게 될 경우 렌더링 되는 과정에서 트리에 UI Node가 추가되어서 성능상 더 좋지 않을 수 있어요.

`Modifier.padding()`으로 표현할 경우 해당 노드에 붙어서 옵션만 달아주는 느낌이라서 훨씬 좋아요!

`Spacer(modifier=Modifer.weight(1f)` 같은 경우에만 Spacer를 사용하면 좋을 것 같습니다~~

<br><br><br>

SideEffect도 Intent로만 호출할 수 있도록 바꾸고,

해당 함수의 예시를 repeatOnStarted()로 하면 될 것 같습니다~