### PR TITLE
[PC-255] 구글 로그인 연동

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -35,6 +35,7 @@ jobs:
           echo "KAKAO_APP_KEY=${{ secrets.KAKAO_APP_KEY }}" >> local.properties
           echo "PIECE_DEV_BASE_URL=${{ secrets.PIECE_DEV_BASE_URL }}" >> local.properties
           echo "PIECE_PROD_BASE_URL=${{ secrets.PIECE_PROD_BASE_URL }}" >> local.properties
+          echo "GOOGLE_WEB_CLIENT_ID=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> local.properties
 
       - name: Build with Gradle
         run: ./gradlew assembleDebug --build-cache --stacktrace

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -38,6 +38,7 @@ jobs:
         echo "KAKAO_APP_KEY=${{ secrets.KAKAO_APP_KEY }}" >> local.properties
         echo "PIECE_DEV_BASE_URL=${{ secrets.PIECE_DEV_BASE_URL }}" >> local.properties
         echo "PIECE_PROD_BASE_URL=${{ secrets.PIECE_PROD_BASE_URL }}" >> local.properties
+        echo "GOOGLE_WEB_CLIENT_ID=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> local.properties
 
     - name: Build with Gradle
       run: ./gradlew assembleDebug --build-cache --stacktrace

--- a/core/designsystem/src/main/java/com/puzzle/designsystem/component/Button.kt
+++ b/core/designsystem/src/main/java/com/puzzle/designsystem/component/Button.kt
@@ -16,6 +16,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -162,8 +166,16 @@ fun PieceLoginButton(
     containerColor: Color = PieceTheme.colors.primaryDefault,
     labelColor: Color = PieceTheme.colors.black
 ) {
+    var lastClickTime by remember { mutableLongStateOf(0L) }
+
     Button(
-        onClick = onClick,
+        onClick = {
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastClickTime >= 2000L) {
+                onClick()
+                lastClickTime = currentTime
+            }
+        },
         enabled = enabled,
         shape = RoundedCornerShape(8.dp),
         border = border,

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -8,6 +8,10 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+
+    implementation(libs.androidx.credentials)
+    implementation(libs.androidx.credentials.play.services.auth)
+    implementation(libs.googleid)
     implementation(libs.kakao.user)
     implementation(libs.accompanist.permission)
 }

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -1,9 +1,21 @@
+import java.util.Properties
+
 plugins {
     id("piece.android.feature")
 }
 
 android {
     namespace = "com.puzzle.auth"
+
+    defaultConfig {
+        val localProperties = Properties()
+        localProperties.load(project.rootProject.file("local.properties").bufferedReader())
+        buildConfigField("String", "GOOGLE_WEB_CLIENT_ID", "\"${localProperties["GOOGLE_WEB_CLIENT_ID"]}\"")
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {
@@ -11,7 +23,8 @@ dependencies {
 
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.play.services.auth)
-    implementation(libs.googleid)
+    implementation(libs.google.id)
+    implementation(libs.google.auth)
     implementation(libs.kakao.user)
     implementation(libs.accompanist.permission)
 }

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -21,9 +21,7 @@ android {
 dependencies {
     implementation(projects.core.common)
 
-    implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.play.services.auth)
-    implementation(libs.google.id)
     implementation(libs.google.auth)
     implementation(libs.kakao.user)
     implementation(libs.accompanist.permission)

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/GoogleApiContract.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/GoogleApiContract.kt
@@ -10,8 +10,8 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.tasks.Task
 import com.puzzle.auth.BuildConfig
 
-internal class GoogleApiContract : ActivityResultContract<Int, Task<GoogleSignInAccount>?>() {
-    override fun createIntent(context: Context, input: Int): Intent {
+internal class GoogleApiContract : ActivityResultContract<Unit, Task<GoogleSignInAccount>?>() {
+    override fun createIntent(context: Context, input: Unit): Intent {
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(BuildConfig.GOOGLE_WEB_CLIENT_ID)
             .requestId()

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/GoogleApiContract.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/GoogleApiContract.kt
@@ -10,7 +10,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.tasks.Task
 import com.puzzle.auth.BuildConfig
 
-class GoogleApiContract : ActivityResultContract<Int, Task<GoogleSignInAccount>?>() {
+internal class GoogleApiContract : ActivityResultContract<Int, Task<GoogleSignInAccount>?>() {
     override fun createIntent(context: Context, input: Int): Intent {
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(BuildConfig.GOOGLE_WEB_CLIENT_ID)

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/GoogleApiContract.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/GoogleApiContract.kt
@@ -1,0 +1,30 @@
+package com.puzzle.auth.graph.login
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.tasks.Task
+import com.puzzle.auth.BuildConfig
+
+class GoogleApiContract : ActivityResultContract<Int, Task<GoogleSignInAccount>?>() {
+    override fun createIntent(context: Context, input: Int): Intent {
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(BuildConfig.GOOGLE_WEB_CLIENT_ID)
+            .requestId()
+            .build()
+
+        val intent = GoogleSignIn.getClient(context, gso)
+        return intent.signInIntent
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Task<GoogleSignInAccount>? {
+        return when (resultCode) {
+            Activity.RESULT_OK -> GoogleSignIn.getSignedInAccountFromIntent(intent)
+            else -> null
+        }
+    }
+}

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
@@ -79,7 +79,7 @@ internal fun LoginRoute(
                         },
                     )
 
-                    is LoginSideEffect.LoginGoogle -> authResultLauncher.launch(1)
+                    is LoginSideEffect.LoginGoogle -> authResultLauncher.launch(Unit)
                 }
             }
         }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
@@ -59,7 +59,7 @@ internal fun LoginRoute(
     ) { task ->
         handleGoogleSignIn(
             task = task,
-            onSuccess = { viewModel.loginOAuth(OAuthProvider.GOOGLE, it) },
+            onSuccess = { accessToken -> viewModel.loginOAuth(OAuthProvider.GOOGLE, accessToken) },
             onFailure = { viewModel.loginFailure(it) },
         )
     }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginScreen.kt
@@ -1,6 +1,7 @@
 package com.puzzle.auth.graph.login
 
 import android.content.Context
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -29,6 +30,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.tasks.Task
 import com.kakao.sdk.user.UserApiClient
 import com.puzzle.auth.graph.login.contract.LoginIntent
 import com.puzzle.auth.graph.login.contract.LoginIntent.Navigate
@@ -51,6 +54,15 @@ internal fun LoginRoute(
     val state by viewModel.collectAsState()
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val authResultLauncher = rememberLauncherForActivityResult(
+        contract = GoogleApiContract()
+    ) { task ->
+        handleGoogleSignIn(
+            task = task,
+            onSuccess = { viewModel.loginOAuth(OAuthProvider.GOOGLE, it) },
+            onFailure = { viewModel.loginFailure(it) },
+        )
+    }
 
     LaunchedEffect(Unit) {
         lifecycleOwner.repeatOnStarted {
@@ -59,15 +71,15 @@ internal fun LoginRoute(
                     is LoginSideEffect.LoginKakao -> loginKakao(
                         context = context,
                         onFailure = { viewModel.loginFailure(it) },
-                        onSuccess = {
+                        onSuccess = { accessToken ->
                             viewModel.loginOAuth(
                                 oAuthProvider = OAuthProvider.KAKAO,
-                                token = it,
+                                token = accessToken,
                             )
                         },
                     )
 
-                    is LoginSideEffect.LoginGoogle -> {}
+                    is LoginSideEffect.LoginGoogle -> authResultLauncher.launch(1)
                 }
             }
         }
@@ -169,8 +181,8 @@ private fun LoginScreen(
 
 private fun loginKakao(
     context: Context,
-    onFailure: (Throwable) -> Unit,
     onSuccess: (String) -> Unit,
+    onFailure: (Throwable) -> Unit,
 ) {
     UserApiClient.instance.apply {
         if (isKakaoTalkLoginAvailable(context)) {
@@ -192,6 +204,33 @@ private fun loginKakao(
                 }
             }
         }
+    }
+}
+
+fun handleGoogleSignIn(
+    task: Task<GoogleSignInAccount>?,
+    onSuccess: (String) -> Unit,
+    onFailure: (Throwable) -> Unit,
+) {
+    if (task == null) {
+        onFailure(IllegalStateException("Google sign-in task is null"))
+        return
+    }
+
+    try {
+        val account = task.result
+        if (account != null) {
+            val idToken = account.idToken
+            if (!idToken.isNullOrEmpty()) {
+                onSuccess(idToken)
+            } else {
+                onFailure(IllegalStateException("ID Token is null or empty"))
+            }
+        } else {
+            onFailure(IllegalStateException("GoogleSignInAccount is null"))
+        }
+    } catch (e: Exception) {
+        onFailure(e)
     }
 }
 

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginViewModel.kt
@@ -48,6 +48,7 @@ class LoginViewModel @AssistedInject constructor(
         when (intent) {
             is LoginIntent.Navigate -> navigationHelper.navigate(intent.navigationEvent)
             is LoginIntent.LoginOAuth -> {
+                setState { copy(isLoading = true) }
                 when (intent.oAuthProvider) {
                     OAuthProvider.KAKAO -> _sideEffects.send(LoginSideEffect.LoginKakao)
                     OAuthProvider.GOOGLE -> _sideEffects.send(LoginSideEffect.LoginGoogle)
@@ -68,9 +69,11 @@ class LoginViewModel @AssistedInject constructor(
                 )
             )
         }.onFailure { errorHelper.sendError(it) }
+            .also { setState { copy(isLoading = false) } }
     }
 
     internal fun loginFailure(throwable: Throwable) {
+        setState { copy(isLoading = false) }
         errorHelper.sendError(throwable)
     }
 

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/contract/LoginState.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/contract/LoginState.kt
@@ -3,5 +3,5 @@ package com.puzzle.auth.graph.login.contract
 import com.airbnb.mvrx.MavericksState
 
 data class LoginState(
-    val a: Boolean = false,
+    val isLoading: Boolean = false,
 ) : MavericksState

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,8 @@ messaging = "24.1.0"
 androidxCredentials = "1.3.0"
 # https://developers.google.com/identity/android-credential-manager/releases
 googleId = "1.1.1"
+# https://developers.google.com/android/guides/releases
+googleAuth = "21.3.0"
 # https://developers.kakao.com/docs/latest/ko/android/getting-started#apply-sdk
 kakao = "2.20.6"
 
@@ -175,7 +177,8 @@ accompanist-permission = { module = "com.google.accompanist:accompanist-permissi
 
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
 androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "androidxCredentials" }
-googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleId" }
+google-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "googleAuth" }
+google-id = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleId" }
 kakao-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakao" }
 
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,11 +44,9 @@ hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 
 ## Network
-# okhttp
-# # https://square.github.io/okhttp/
+# https://square.github.io/okhttp/
 okhttp = "4.12.0"
-# Retrofit
-# # https://github.com/square/retrofit
+# https://github.com/square/retrofit
 retrofit = "2.11.0"
 
 ## Kotlin
@@ -78,14 +76,21 @@ firebaseBom = "33.7.0"
 crashlytics = "3.0.2"
 messaging = "24.1.0"
 
+## OAuth
+# https://developer.android.com/jetpack/androidx/releases/credentials
+androidxCredentials = "1.3.0"
+# https://developers.google.com/identity/android-credential-manager/releases
+googleId = "1.1.1"
+# https://developers.kakao.com/docs/latest/ko/android/getting-started#apply-sdk
+kakao = "2.20.6"
+
+
 # https://coil-kt.github.io/coil/#jetpack-compose
 coil = "2.7.0"
 # https://airbnb.io/lottie/#/android-compose
 lottie-compose = "6.5.2"
 # https://github.com/skydoves/Cloudy
 cloudy = "0.2.4"
-# https://developers.kakao.com/docs/latest/ko/android/getting-started#apply-sdk
-kakao = "2.20.6"
 # https://airbnb.io/mavericks/#/setup
 mavericks = "3.0.9"
 
@@ -158,23 +163,26 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
 
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
-firebase-config = { group = "com.google.firebase", name = "firebase-config-ktx" }
-firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "messaging" }
+mavericks = { module = "com.airbnb.android:mavericks", version.ref = "mavericks" }
+mavericks-compose = { module = "com.airbnb.android:mavericks-compose", version.ref = "mavericks" }
+mavericks-hilt = { module = "com.airbnb.android:mavericks-hilt", version.ref = "mavericks" }
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie-compose" }
 cloudy-compose = { module = "com.github.skydoves:cloudy", version.ref = "cloudy" }
 
+accompanist-permission = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
+
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
+androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "androidxCredentials" }
+googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleId" }
 kakao-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakao" }
 
-mavericks = { module = "com.airbnb.android:mavericks", version.ref = "mavericks" }
-mavericks-compose = { module = "com.airbnb.android:mavericks-compose", version.ref = "mavericks" }
-mavericks-hilt = { module = "com.airbnb.android:mavericks-hilt", version.ref = "mavericks" }
-
-accompanist-permission = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-config = { group = "com.google.firebase", name = "firebase-config-ktx" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "messaging" }
 
 [bundles]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,8 +79,6 @@ messaging = "24.1.0"
 ## OAuth
 # https://developer.android.com/jetpack/androidx/releases/credentials
 androidxCredentials = "1.3.0"
-# https://developers.google.com/identity/android-credential-manager/releases
-googleId = "1.1.1"
 # https://developers.google.com/android/guides/releases
 googleAuth = "21.3.0"
 # https://developers.kakao.com/docs/latest/ko/android/getting-started#apply-sdk
@@ -175,10 +173,8 @@ cloudy-compose = { module = "com.github.skydoves:cloudy", version.ref = "cloudy"
 
 accompanist-permission = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
 
-androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
 androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "androidxCredentials" }
 google-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "googleAuth" }
-google-id = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleId" }
 kakao-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakao" }
 
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- **구글 로그인 연동**

## 2. 🖼️ 스크린샷(선택)

일단 토큰은 받아와지고, API 호출은 되는데 구글 로그인에서 에러가 떠서

서버 개발자님들이랑 조율중입니다!

## 3. 💡 알게된 부분

[구글 로그인을 Compose에서 사용하는 방법](https://velog.io/@milkbottle0305/Jetpack-compose%EC%97%90%EC%84%9C-%EA%B5%AC%EA%B8%80%EA%B3%BC-%EC%B9%B4%ED%86%A1%EB%A1%9C%EA%B7%B8%EC%9D%B8%EC%9D%84-%EA%B5%AC%ED%98%84%ED%95%B4%EB%B3%B4%EC%9E%90)

- **ActivityResultLauncher를 Compose에서 사용하는 방법**

아래와 같은 코드를 작성하면,

```kotlin
class GoogleApiContract : ActivityResultContract<Int, Task<GoogleSignInAccount>?>() {
    override fun createIntent(context: Context, input: Int): Intent {
        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
            .requestIdToken(BuildConfig.GOOGLE_WEB_CLIENT_ID)
            .requestId()
            .build()

        val intent = GoogleSignIn.getClient(context, gso)
        return intent.signInIntent
    }

    override fun parseResult(resultCode: Int, intent: Intent?): Task<GoogleSignInAccount>? {
        return when (resultCode) {
            Activity.RESULT_OK -> GoogleSignIn.getSignedInAccountFromIntent(intent)
            else -> null
        }
    }
}
```

<br><br><br>

```kotlin
    val authResultLauncher = rememberLauncherForActivityResult(
        contract = GoogleApiContract()
    ) { task ->
        handleGoogleSignIn(
            task = task,
            onSuccess = { accessToken -> viewModel.loginOAuth(OAuthProvider.GOOGLE, accessToken) },
            onFailure = { viewModel.loginFailure(it) },
        )
    }
```

위와 같이 rememberLaucherForActivityResult로 콜백을 받을 수 있습니다!

원래는 Activity내에서만 가능했는데 컴포즈에서는 이런식으로 사용할 수 있더라고요!

<br><br><br>

함수를 호출하는 방법은,

```kotlin
authResultLauncher.launch(1)
```

인데, 넘겨주는 1은 원래 GoogleApiContract에서 input으로 분기를 줘서 수행하는 로직을 분기주는 거지만,

우리는 현재 구글 로그인 하나만 사용하고 있기 때문에 아무런 상수나 넣어줘도 다 호출이 가능합니다.

그래서 일단 1을 넣었는데, 더 우아한 방법이 있는지 궁금합니다.