### PR TITLE
[PC-000] 불필요한 보일러 플레이트 SideEffects 제거 및 네비게이션 애니메이션 점프 하던 UI 수정

### DIFF
--- a/core/common-ui/src/main/java/com/puzzle/common/ui/ModifierUtil.kt
+++ b/core/common-ui/src/main/java/com/puzzle/common/ui/ModifierUtil.kt
@@ -8,11 +8,8 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -128,14 +125,9 @@ fun Modifier.verticalScrollbar(
 
 @Composable
 fun Modifier.windowInsetsPadding(): Modifier = composed {
-    this.padding(
-        top = WindowInsets.systemBars
-            .asPaddingValues()
-            .calculateTopPadding(),
-        bottom = WindowInsets.navigationBars
-            .asPaddingValues()
-            .calculateBottomPadding(),
-    )
+    this
+        .navigationBarsPadding()
+        .statusBarsPadding()
 }
 
 @Composable

--- a/core/common-ui/src/main/java/com/puzzle/common/ui/ModifierUtil.kt
+++ b/core/common-ui/src/main/java/com/puzzle/common/ui/ModifierUtil.kt
@@ -8,8 +8,11 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -125,9 +128,14 @@ fun Modifier.verticalScrollbar(
 
 @Composable
 fun Modifier.windowInsetsPadding(): Modifier = composed {
-    this
-        .navigationBarsPadding()
-        .statusBarsPadding()
+    this.padding(
+        top = WindowInsets.systemBars
+            .asPaddingValues()
+            .calculateTopPadding(),
+        bottom = WindowInsets.navigationBars
+            .asPaddingValues()
+            .calculateBottomPadding(),
+    )
 }
 
 @Composable

--- a/core/data/src/main/java/com/puzzle/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/puzzle/data/repository/AuthRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.puzzle.common.suspendRunCatching
 import com.puzzle.datastore.datasource.token.LocalTokenDataSource
 import com.puzzle.datastore.datasource.user.LocalUserDataSource
 import com.puzzle.domain.model.auth.OAuthProvider
+import com.puzzle.domain.model.user.UserRole
 import com.puzzle.domain.repository.AuthRepository
 import com.puzzle.network.source.auth.AuthDataSource
 import kotlinx.coroutines.coroutineScope
@@ -19,7 +20,7 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun loginOauth(
         oAuthProvider: OAuthProvider,
         oauthCredential: String
-    ): Result<Unit> = suspendRunCatching {
+    ): Result<UserRole> = suspendRunCatching {
         val response = authDataSource.loginOauth(oAuthProvider, oauthCredential).getOrThrow()
 
         coroutineScope {
@@ -37,6 +38,8 @@ class AuthRepositoryImpl @Inject constructor(
             refreshTokenJob.join()
             userRoleJob.join()
         }
+
+        UserRole.create(response.role)
     }
 
     override suspend fun logout(): Result<Unit> = suspendRunCatching {

--- a/core/domain/src/main/java/com/puzzle/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/puzzle/domain/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.puzzle.domain.repository
 
 import com.puzzle.domain.model.auth.OAuthProvider
+import com.puzzle.domain.model.user.UserRole
 
 interface AuthRepository {
     suspend fun requestAuthCode(phoneNumber: String): Result<Unit>
@@ -12,7 +13,7 @@ interface AuthRepository {
     suspend fun loginOauth(
         oAuthProvider: OAuthProvider,
         oauthCredential: String
-    ): Result<Unit>
+    ): Result<UserRole>
 
     suspend fun logout(): Result<Unit>
     suspend fun withdraw(reason: String): Result<Unit>

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/login/LoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.puzzle.auth.graph.login
 
+import android.util.Log
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
@@ -22,10 +23,8 @@ import com.puzzle.navigation.NavigationHelper
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -70,9 +69,8 @@ class LoginViewModel @AssistedInject constructor(
         authRepository.loginOauth(
             oAuthProvider = oAuthProvider,
             oauthCredential = token,
-        ).onSuccess {
-            val userRole = async { userRepository.getUserRole().first() }
-                .await()
+        ).onSuccess { userRole ->
+            Log.d("test", userRole.toString())
 
             when (userRole) {
                 REGISTER -> {

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/signup/SignUpViewModel.kt
@@ -106,6 +106,11 @@ class SignUpViewModel @AssistedInject constructor(
     }
 
     private fun onBackClick() = withState { state ->
+        if (state.signUpPage == SignUpState.SignUpPage.TermPage) {
+            navigationHelper.navigate(NavigationEvent.Up)
+            return@withState
+        }
+
         SignUpState.SignUpPage.getPreviousPage(state.signUpPage)?.let {
             setState { copy(signUpPage = it) }
         }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/signup/SignUpViewModel.kt
@@ -5,14 +5,15 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
 import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
 import com.puzzle.auth.graph.signup.contract.SignUpIntent
-import com.puzzle.auth.graph.signup.contract.SignUpSideEffect
-import com.puzzle.auth.graph.signup.contract.SignUpSideEffect.Navigate
 import com.puzzle.auth.graph.signup.contract.SignUpState
 import com.puzzle.common.event.EventHelper
+import com.puzzle.common.event.PieceEvent
 import com.puzzle.domain.model.error.ErrorHelper
 import com.puzzle.domain.repository.MatchingRepository
 import com.puzzle.domain.repository.TermsRepository
+import com.puzzle.navigation.NavigationEvent
 import com.puzzle.navigation.NavigationHelper
+import com.puzzle.navigation.ProfileGraphDest
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -28,14 +29,11 @@ class SignUpViewModel @AssistedInject constructor(
     @Assisted initialState: SignUpState,
     private val termsRepository: TermsRepository,
     private val matchingRepository: MatchingRepository,
-    internal val navigationHelper: NavigationHelper,
+    private val navigationHelper: NavigationHelper,
     private val errorHelper: ErrorHelper,
-    internal val eventHelper: EventHelper,
+    private val eventHelper: EventHelper,
 ) : MavericksViewModel<SignUpState>(initialState) {
     private val _intents = Channel<SignUpIntent>(BUFFERED)
-
-    private val _sideEffects = Channel<SignUpSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         fetchTerms()
@@ -57,12 +55,14 @@ class SignUpViewModel @AssistedInject constructor(
             is SignUpIntent.OnTermDetailClick -> onTermDetailClick()
             is SignUpIntent.OnBackClick -> onBackClick()
             is SignUpIntent.OnNextClick -> onNextClick()
-            is SignUpIntent.OnDisEnabledButtonClick -> _sideEffects.send(
-                SignUpSideEffect.ShowSnackBar("필수 권한을 허용해주세요")
+            is SignUpIntent.OnDisEnabledButtonClick -> eventHelper.sendEvent(
+                PieceEvent.ShowSnackBar("필수 권한을 허용해주세요")
             )
 
             is SignUpIntent.OnAvoidAcquaintancesClick -> blockContacts(intent.phoneNumbers)
-            is SignUpIntent.Navigate -> _sideEffects.send(Navigate(intent.navigationEvent))
+            is SignUpIntent.OnGenerateProfileClick -> navigationHelper.navigate(
+                NavigationEvent.To(ProfileGraphDest.RegisterProfileRoute)
+            )
         }
     }
 

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/signup/contract/SignUpIntent.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/signup/contract/SignUpIntent.kt
@@ -1,7 +1,5 @@
 package com.puzzle.auth.graph.signup.contract
 
-import com.puzzle.navigation.NavigationEvent
-
 sealed class SignUpIntent {
     data object CheckAllTerms : SignUpIntent()
     data class CheckTerm(val termId: Int) : SignUpIntent()
@@ -11,5 +9,5 @@ sealed class SignUpIntent {
     data object OnNextClick : SignUpIntent()
     data object OnDisEnabledButtonClick : SignUpIntent()
     data class OnAvoidAcquaintancesClick(val phoneNumbers: List<String>) : SignUpIntent()
-    data class Navigate(val navigationEvent: NavigationEvent) : SignUpIntent()
+    data object OnGenerateProfileClick : SignUpIntent()
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/signup/contract/SignUpSideEffect.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/signup/contract/SignUpSideEffect.kt
@@ -1,9 +1,0 @@
-package com.puzzle.auth.graph.signup.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class SignUpSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : SignUpSideEffect()
-    data class ShowSnackBar(val msg: String) : SignUpSideEffect()
-    data object HideSnackBar : SignUpSideEffect()
-}

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/verification/contract/VerificationIntent.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/verification/contract/VerificationIntent.kt
@@ -1,9 +1,8 @@
 package com.puzzle.auth.graph.verification.contract
 
-import com.puzzle.navigation.NavigationEvent
-
 sealed class VerificationIntent {
     data class OnRequestAuthCodeClick(val phoneNumber: String) : VerificationIntent()
     data class OnVerifyClick(val phoneNumber: String, val code: String) : VerificationIntent()
-    data class Navigate(val navigationEvent: NavigationEvent) : VerificationIntent()
+    data object OnBackClick : VerificationIntent()
+    data object OnNextClick : VerificationIntent()
 }

--- a/feature/auth/src/main/java/com/puzzle/auth/graph/verification/contract/VerificationSideEffect.kt
+++ b/feature/auth/src/main/java/com/puzzle/auth/graph/verification/contract/VerificationSideEffect.kt
@@ -1,9 +1,0 @@
-package com.puzzle.auth.graph.verification.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class VerificationSideEffect {
-    data class RequestAuthCode(val phoneNumber: String) : VerificationSideEffect()
-    data class VerifyAuthCode(val phoneNumber: String, val code: String) : VerificationSideEffect()
-    data class Navigate(val navigationEvent: NavigationEvent) : VerificationSideEffect()
-}

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/block/BlockScreen.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/block/BlockScreen.kt
@@ -32,7 +32,6 @@ import com.puzzle.designsystem.component.PieceSolidButton
 import com.puzzle.designsystem.component.PieceSubBackTopBar
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.matching.graph.block.contract.BlockIntent
-import com.puzzle.matching.graph.block.contract.BlockSideEffect
 import com.puzzle.matching.graph.block.contract.BlockState
 
 @Composable
@@ -42,18 +41,6 @@ internal fun BlockRoute(
     viewModel: BlockViewModel = mavericksViewModel(),
 ) {
     val state by viewModel.collectAsState()
-
-    val lifecycleOwner = LocalLifecycleOwner.current
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is BlockSideEffect.Navigate -> viewModel.navigationHelper
-                        .navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
 
     BlockScreen(
         state = state,

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/block/BlockViewModel.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/block/BlockViewModel.kt
@@ -7,7 +7,6 @@ import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
 import com.puzzle.domain.model.error.ErrorHelper
 import com.puzzle.domain.repository.MatchingRepository
 import com.puzzle.matching.graph.block.contract.BlockIntent
-import com.puzzle.matching.graph.block.contract.BlockSideEffect
 import com.puzzle.matching.graph.block.contract.BlockState
 import com.puzzle.navigation.MatchingGraphDest
 import com.puzzle.navigation.NavigationEvent
@@ -29,8 +28,6 @@ class BlockViewModel @AssistedInject constructor(
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<BlockState>(initialState) {
     private val intents = Channel<BlockIntent>(BUFFERED)
-    private val _sideEffects = Channel<BlockSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         intents.receiveAsFlow()
@@ -44,14 +41,12 @@ class BlockViewModel @AssistedInject constructor(
 
     private suspend fun processIntent(intent: BlockIntent) {
         when (intent) {
-            BlockIntent.OnBackClick -> _sideEffects.send(BlockSideEffect.Navigate(NavigationEvent.Up))
+            BlockIntent.OnBackClick -> navigationHelper.navigate(NavigationEvent.Up)
             is BlockIntent.OnBlockButtonClick -> blockUser(intent.userId)
-            BlockIntent.OnBlockDoneClick -> _sideEffects.send(
-                BlockSideEffect.Navigate(
-                    NavigationEvent.To(
-                        route = MatchingGraphDest.MatchingRoute,
-                        popUpTo = true,
-                    )
+            BlockIntent.OnBlockDoneClick -> navigationHelper.navigate(
+                NavigationEvent.To(
+                    route = MatchingGraphDest.MatchingRoute,
+                    popUpTo = true,
                 )
             )
         }

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/block/contract/BlockSideEffect.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/block/contract/BlockSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.matching.graph.block.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class BlockSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : BlockSideEffect()
-}

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/contact/ContactScreen.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/contact/ContactScreen.kt
@@ -56,7 +56,6 @@ import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.domain.model.profile.Contact
 import com.puzzle.domain.model.profile.ContactType
 import com.puzzle.matching.graph.contact.contract.ContactIntent
-import com.puzzle.matching.graph.contact.contract.ContactSideEffect
 import com.puzzle.matching.graph.contact.contract.ContactState
 import com.puzzle.matching.graph.contact.contract.getContactIconId
 import com.puzzle.matching.graph.contact.contract.getContactNameId
@@ -69,18 +68,6 @@ internal fun ContactRoute(
     viewModel: ContactViewModel = mavericksViewModel(),
 ) {
     val state by viewModel.collectAsState()
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is ContactSideEffect.Navigate ->
-                        viewModel.navigationHelper.navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
 
     ContactScreen(
         state = state,

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/contact/ContactViewModel.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/contact/ContactViewModel.kt
@@ -9,7 +9,6 @@ import com.puzzle.domain.model.profile.Contact
 import com.puzzle.domain.repository.MatchingRepository
 import com.puzzle.domain.usecase.matching.GetOpponentProfileUseCase
 import com.puzzle.matching.graph.contact.contract.ContactIntent
-import com.puzzle.matching.graph.contact.contract.ContactSideEffect
 import com.puzzle.matching.graph.contact.contract.ContactState
 import com.puzzle.navigation.NavigationEvent
 import com.puzzle.navigation.NavigationHelper
@@ -31,8 +30,6 @@ class ContactViewModel @AssistedInject constructor(
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<ContactState>(initialState) {
     private val intents = Channel<ContactIntent>(BUFFERED)
-    private val _sideEffects = Channel<ContactSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         intents.receiveAsFlow()
@@ -78,7 +75,7 @@ class ContactViewModel @AssistedInject constructor(
 
     private suspend fun processIntent(intent: ContactIntent) {
         when (intent) {
-            ContactIntent.OnCloseClick -> moveToBackScreen()
+            ContactIntent.OnCloseClick -> navigationHelper.navigate(NavigationEvent.Up)
             is ContactIntent.OnContactClick -> updateSelectedContact(intent.selectedContact)
         }
     }
@@ -87,10 +84,6 @@ class ContactViewModel @AssistedInject constructor(
         setState {
             copy(selectedContact = selectedContact)
         }
-    }
-
-    private suspend fun moveToBackScreen() {
-        _sideEffects.send(ContactSideEffect.Navigate(NavigationEvent.Up))
     }
 
     @AssistedFactory

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/contact/contract/ContactSideEffect.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/contact/contract/ContactSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.matching.graph.contact.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class ContactSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : ContactSideEffect()
-}

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/MatchingDetailScreen.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/MatchingDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,13 +33,11 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.puzzle.common.ui.ANIMATION_DURATION
 import com.puzzle.common.ui.blur
 import com.puzzle.common.ui.clickable
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.common.ui.windowInsetsPadding
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceDialog
@@ -56,7 +53,6 @@ import com.puzzle.domain.model.profile.OpponentProfile
 import com.puzzle.matching.graph.detail.bottomsheet.MatchingDetailMoreBottomSheet
 import com.puzzle.matching.graph.detail.common.constant.DialogType
 import com.puzzle.matching.graph.detail.contract.MatchingDetailIntent
-import com.puzzle.matching.graph.detail.contract.MatchingDetailSideEffect
 import com.puzzle.matching.graph.detail.contract.MatchingDetailState
 import com.puzzle.matching.graph.detail.contract.MatchingDetailState.MatchingDetailPage
 import com.puzzle.matching.graph.detail.page.BasicInfoPage
@@ -69,18 +65,6 @@ internal fun MatchingDetailRoute(
     viewModel: MatchingDetailViewModel = mavericksViewModel()
 ) {
     val state by viewModel.collectAsState()
-
-    val lifecycleOwner = LocalLifecycleOwner.current
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is MatchingDetailSideEffect.Navigate -> viewModel.navigationHelper
-                        .navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
 
     MatchingDetailScreen(
         state = state,

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/MatchingDetailViewModel.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/MatchingDetailViewModel.kt
@@ -11,7 +11,6 @@ import com.puzzle.domain.model.error.ErrorHelper
 import com.puzzle.domain.repository.MatchingRepository
 import com.puzzle.domain.usecase.matching.GetOpponentProfileUseCase
 import com.puzzle.matching.graph.detail.contract.MatchingDetailIntent
-import com.puzzle.matching.graph.detail.contract.MatchingDetailSideEffect
 import com.puzzle.matching.graph.detail.contract.MatchingDetailState
 import com.puzzle.navigation.MatchingGraphDest
 import com.puzzle.navigation.NavigationEvent
@@ -30,13 +29,11 @@ class MatchingDetailViewModel @AssistedInject constructor(
     @Assisted initialState: MatchingDetailState,
     private val getOpponentProfileUseCase: GetOpponentProfileUseCase,
     private val matchingRepository: MatchingRepository,
-    internal val navigationHelper: NavigationHelper,
+    private val navigationHelper: NavigationHelper,
     private val eventHelper: EventHelper,
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<MatchingDetailState>(initialState) {
     private val intents = Channel<MatchingDetailIntent>(BUFFERED)
-    private val _sideEffects = Channel<MatchingDetailSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         intents.receiveAsFlow()

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/detail/contract/MatchingDetailSideEffect.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/detail/contract/MatchingDetailSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.matching.graph.detail.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class MatchingDetailSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : MatchingDetailSideEffect()
-}

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/main/MatchingScreen.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/main/MatchingScreen.kt
@@ -4,17 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.domain.model.match.MatchInfo
 import com.puzzle.domain.model.match.MatchStatus
 import com.puzzle.domain.model.match.MatchStatus.WAITING
 import com.puzzle.domain.model.user.UserRole
 import com.puzzle.matching.graph.main.contract.MatchingIntent
-import com.puzzle.matching.graph.main.contract.MatchingSideEffect
 import com.puzzle.matching.graph.main.contract.MatchingState
 import com.puzzle.matching.graph.main.page.MatchingLoadingScreen
 import com.puzzle.matching.graph.main.page.MatchingPendingScreen
@@ -27,18 +24,7 @@ internal fun MatchingRoute(
 ) {
     val state by viewModel.collectAsState()
 
-    val lifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is MatchingSideEffect.Navigate -> {
-                        viewModel.navigationHelper.navigate(sideEffect.navigationEvent)
-                    }
-                }
-            }
-        }
-
         viewModel.initMatchInfo()
     }
 

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/main/MatchingViewModel.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/main/MatchingViewModel.kt
@@ -19,7 +19,6 @@ import com.puzzle.domain.repository.ConfigureRepository
 import com.puzzle.domain.repository.MatchingRepository
 import com.puzzle.domain.repository.UserRepository
 import com.puzzle.matching.graph.main.contract.MatchingIntent
-import com.puzzle.matching.graph.main.contract.MatchingSideEffect
 import com.puzzle.matching.graph.main.contract.MatchingState
 import com.puzzle.navigation.MatchingGraphDest
 import com.puzzle.navigation.NavigationEvent.To
@@ -47,8 +46,6 @@ class MatchingViewModel @AssistedInject constructor(
     internal val navigationHelper: NavigationHelper,
 ) : MavericksViewModel<MatchingState>(initialState) {
     private val intents = Channel<MatchingIntent>(BUFFERED)
-    private val _sideEffects = Channel<MatchingSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     private var timerJob: Job? = null
 
@@ -175,10 +172,8 @@ class MatchingViewModel @AssistedInject constructor(
                     setState { copy(matchInfo = matchInfo?.copy(matchStatus = MatchStatus.WAITING)) }
                 }.onFailure { errorHelper.sendError(it) }
 
-            _sideEffects.send(
-                MatchingSideEffect.Navigate(
-                    To(MatchingGraphDest.MatchingDetailRoute(it.matchInfo!!.matchId))
-                )
+            navigationHelper.navigate(
+                To(MatchingGraphDest.MatchingDetailRoute(it.matchInfo!!.matchId))
             )
         }
     }

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/main/contract/MatchingSideEffect.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/main/contract/MatchingSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.matching.graph.main.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class MatchingSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : MatchingSideEffect()
-}

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/preview/ProfilePreviewViewModel.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/preview/ProfilePreviewViewModel.kt
@@ -9,7 +9,6 @@ import com.puzzle.domain.repository.ProfileRepository
 import com.puzzle.domain.usecase.profile.GetMyValuePicksUseCase
 import com.puzzle.domain.usecase.profile.GetMyValueTalksUseCase
 import com.puzzle.matching.graph.preview.contract.ProfilePreviewIntent
-import com.puzzle.matching.graph.preview.contract.ProfilePreviewSideEffect
 import com.puzzle.matching.graph.preview.contract.ProfilePreviewState
 import com.puzzle.navigation.MatchingGraphDest
 import com.puzzle.navigation.NavigationEvent
@@ -33,8 +32,6 @@ class ProfilePreviewViewModel @AssistedInject constructor(
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<ProfilePreviewState>(initialState) {
     private val intents = Channel<ProfilePreviewIntent>(BUFFERED)
-    private val _sideEffects = Channel<ProfilePreviewSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         initProfilePreview()

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/preview/contract/ProfilePreviewSideEffect.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/preview/contract/ProfilePreviewSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.matching.graph.preview.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class ProfilePreviewSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : ProfilePreviewSideEffect()
-}

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/report/ReportScreen.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/report/ReportScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,11 +23,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.puzzle.common.ui.addFocusCleaner
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceDialog
 import com.puzzle.designsystem.component.PieceDialogBottom
@@ -39,7 +36,6 @@ import com.puzzle.designsystem.component.PieceSubBackTopBar
 import com.puzzle.designsystem.component.PieceTextInputLong
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.matching.graph.report.contract.ReportIntent
-import com.puzzle.matching.graph.report.contract.ReportSideEffect
 import com.puzzle.matching.graph.report.contract.ReportState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -51,18 +47,7 @@ internal fun ReportRoute(
     viewModel: ReportViewModel = mavericksViewModel(),
 ) {
     val state by viewModel.collectAsState()
-    val lifecycleOwner = LocalLifecycleOwner.current
 
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is ReportSideEffect.Navigate ->
-                        viewModel.navigationHelper.navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
     ReportScreen(
         state = state,
         userName = userName,

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/report/ReportViewModel.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/report/ReportViewModel.kt
@@ -7,7 +7,6 @@ import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
 import com.puzzle.domain.model.error.ErrorHelper
 import com.puzzle.domain.repository.MatchingRepository
 import com.puzzle.matching.graph.report.contract.ReportIntent
-import com.puzzle.matching.graph.report.contract.ReportSideEffect
 import com.puzzle.matching.graph.report.contract.ReportState
 import com.puzzle.navigation.MatchingGraphDest
 import com.puzzle.navigation.NavigationEvent
@@ -29,9 +28,6 @@ class ReportViewModel @AssistedInject constructor(
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<ReportState>(initialState) {
     private val intents = Channel<ReportIntent>(BUFFERED)
-    private val _sideEffects = Channel<ReportSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
-
     init {
         intents.receiveAsFlow()
             .onEach(::processIntent)
@@ -44,21 +40,17 @@ class ReportViewModel @AssistedInject constructor(
 
     private suspend fun processIntent(intent: ReportIntent) {
         when (intent) {
-            ReportIntent.OnBackClick -> _sideEffects.send(
-                ReportSideEffect.Navigate(NavigationEvent.Up)
-            )
+            ReportIntent.OnBackClick -> navigationHelper.navigate(NavigationEvent.Up)
 
             is ReportIntent.OnReportButtonClick -> reportUser(
                 userId = intent.userId,
                 reason = intent.reason
             )
 
-            ReportIntent.OnReportDoneClick -> _sideEffects.send(
-                ReportSideEffect.Navigate(
-                    NavigationEvent.To(
-                        route = MatchingGraphDest.MatchingRoute,
-                        popUpTo = true,
-                    )
+            ReportIntent.OnReportDoneClick -> navigationHelper.navigate(
+                NavigationEvent.To(
+                    route = MatchingGraphDest.MatchingRoute,
+                    popUpTo = true,
                 )
             )
 

--- a/feature/matching/src/main/java/com/puzzle/matching/graph/report/contract/ReportSideEffect.kt
+++ b/feature/matching/src/main/java/com/puzzle/matching/graph/report/contract/ReportSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.matching.graph.report.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class ReportSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : ReportSideEffect()
-}

--- a/feature/onboarding/src/main/java/com/puzzle/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/puzzle/onboarding/OnboardingScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,44 +32,15 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceSolidButton
 import com.puzzle.designsystem.foundation.PieceTheme
-import com.puzzle.navigation.AuthGraphDest
-import com.puzzle.navigation.NavigationEvent
 import com.puzzle.onboarding.contract.OnboardingIntent
-import com.puzzle.onboarding.contract.OnboardingSideEffect
 import kotlinx.coroutines.launch
 
 @Composable
 internal fun OnboardingRoute(viewModel: OnboardingViewModel = hiltViewModel()) {
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is OnboardingSideEffect.Navigate ->
-                        viewModel.navigationHelper.navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
-
-    OnboardingScreen(
-        onStartButtonClick = {
-            viewModel.onIntent(
-                OnboardingIntent.Navigate(
-                    NavigationEvent.To(
-                        route = AuthGraphDest.LoginRoute,
-                        popUpTo = true,
-                    )
-                )
-            )
-        }
-    )
+    OnboardingScreen(onStartButtonClick = { viewModel.onIntent(OnboardingIntent.OnStartClick) })
 }
 
 @Composable

--- a/feature/onboarding/src/main/java/com/puzzle/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/puzzle/onboarding/OnboardingViewModel.kt
@@ -2,9 +2,10 @@ package com.puzzle.onboarding
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.puzzle.navigation.AuthGraphDest
+import com.puzzle.navigation.NavigationEvent
 import com.puzzle.navigation.NavigationHelper
 import com.puzzle.onboarding.contract.OnboardingIntent
-import com.puzzle.onboarding.contract.OnboardingSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
@@ -19,8 +20,6 @@ class OnboardingViewModel @Inject constructor(
     internal val navigationHelper: NavigationHelper,
 ) : ViewModel() {
     private val intents = Channel<OnboardingIntent>(BUFFERED)
-    private val _sideEffects = Channel<OnboardingSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         intents.receiveAsFlow()
@@ -32,10 +31,14 @@ class OnboardingViewModel @Inject constructor(
         intents.send(intent)
     }
 
-    private suspend fun processIntent(intent: OnboardingIntent) {
+    private fun processIntent(intent: OnboardingIntent) {
         when (intent) {
-            is OnboardingIntent.Navigate -> _sideEffects.send(OnboardingSideEffect.Navigate(intent.navigationEvent))
+            is OnboardingIntent.OnStartClick -> navigationHelper.navigate(
+                NavigationEvent.To(
+                    route = AuthGraphDest.LoginRoute,
+                    popUpTo = true,
+                )
+            )
         }
     }
-
 }

--- a/feature/onboarding/src/main/java/com/puzzle/onboarding/contract/OnboardingIntent.kt
+++ b/feature/onboarding/src/main/java/com/puzzle/onboarding/contract/OnboardingIntent.kt
@@ -1,7 +1,5 @@
 package com.puzzle.onboarding.contract
 
-import com.puzzle.navigation.NavigationEvent
-
 sealed class OnboardingIntent {
-    data class Navigate(val navigationEvent: NavigationEvent) : OnboardingIntent()
+    data object OnStartClick : OnboardingIntent()
 }

--- a/feature/onboarding/src/main/java/com/puzzle/onboarding/contract/OnboardingSideEffect.kt
+++ b/feature/onboarding/src/main/java/com/puzzle/onboarding/contract/OnboardingSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.onboarding.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class OnboardingSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : OnboardingSideEffect()
-}

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/basic/BasicProfileScreen.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/basic/BasicProfileScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,12 +42,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.isDigitsOnly
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import coil3.compose.AsyncImage
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.puzzle.common.ui.addFocusCleaner
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.common.ui.throttledClickable
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceChip
@@ -61,7 +58,6 @@ import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.domain.model.profile.Contact
 import com.puzzle.domain.model.profile.ContactType
 import com.puzzle.profile.graph.basic.contract.BasicProfileIntent
-import com.puzzle.profile.graph.basic.contract.BasicProfileSideEffect
 import com.puzzle.profile.graph.basic.contract.BasicProfileState
 import com.puzzle.profile.graph.basic.contract.InputState
 import com.puzzle.profile.graph.basic.contract.NickNameGuideMessage
@@ -75,18 +71,6 @@ internal fun BasicProfileRoute(
     viewModel: BasicProfileViewModel = mavericksViewModel()
 ) {
     val state by viewModel.collectAsState()
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is BasicProfileSideEffect.Navigate ->
-                        viewModel.navigationHelper.navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
 
     BasicProfileScreen(
         state = state,

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/basic/BasicProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/basic/BasicProfileViewModel.kt
@@ -16,7 +16,6 @@ import com.puzzle.domain.repository.ProfileRepository
 import com.puzzle.navigation.NavigationEvent
 import com.puzzle.navigation.NavigationHelper
 import com.puzzle.profile.graph.basic.contract.BasicProfileIntent
-import com.puzzle.profile.graph.basic.contract.BasicProfileSideEffect
 import com.puzzle.profile.graph.basic.contract.BasicProfileState
 import com.puzzle.profile.graph.basic.contract.InputState
 import com.puzzle.profile.graph.basic.contract.InputState.Companion.getBirthDateInputState
@@ -43,9 +42,6 @@ class BasicProfileViewModel @AssistedInject constructor(
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<BasicProfileState>(initialState) {
     private val intents = Channel<BasicProfileIntent>(BUFFERED)
-    private val _sideEffects = Channel<BasicProfileSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
-
     private val initialState: BasicProfileState = BasicProfileState()
 
     init {
@@ -105,9 +101,7 @@ class BasicProfileViewModel @AssistedInject constructor(
     }
 
     private suspend fun moveToBackScreen() {
-        _sideEffects.send(
-            BasicProfileSideEffect.Navigate(NavigationEvent.Up)
-        )
+        navigationHelper.navigate(NavigationEvent.Up)
     }
 
     private fun saveBasicProfile() {

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/basic/contract/BasicProfileSideEffect.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/basic/contract/BasicProfileSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.profile.graph.basic.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class BasicProfileSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : BasicProfileSideEffect()
-}

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/main/MainProfileScreen.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/main/MainProfileScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,16 +27,13 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.puzzle.common.ui.clickable
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceMainTopBar
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.profile.graph.main.contract.MainProfileIntent
-import com.puzzle.profile.graph.main.contract.MainProfileSideEffect
 import com.puzzle.profile.graph.main.contract.MainProfileState
 
 @Composable
@@ -45,18 +41,6 @@ internal fun MainProfileRoute(
     viewModel: MainProfileViewModel = mavericksViewModel()
 ) {
     val state by viewModel.collectAsState()
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is MainProfileSideEffect.Navigate ->
-                        viewModel.navigationHelper.navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
 
     MainProfileScreen(
         state = state,

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/main/MainProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/main/MainProfileViewModel.kt
@@ -11,7 +11,6 @@ import com.puzzle.navigation.NavigationEvent
 import com.puzzle.navigation.NavigationHelper
 import com.puzzle.navigation.ProfileGraphDest
 import com.puzzle.profile.graph.main.contract.MainProfileIntent
-import com.puzzle.profile.graph.main.contract.MainProfileSideEffect
 import com.puzzle.profile.graph.main.contract.MainProfileState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -30,10 +29,7 @@ class MainProfileViewModel @AssistedInject constructor(
     internal val navigationHelper: NavigationHelper,
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<MainProfileState>(initialState) {
-
     private val intents = Channel<MainProfileIntent>(BUFFERED)
-    private val _sideEffects = Channel<MainProfileSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         initMainProfile()
@@ -73,29 +69,23 @@ class MainProfileViewModel @AssistedInject constructor(
 
     private suspend fun processIntent(intent: MainProfileIntent) {
         when (intent) {
-            is MainProfileIntent.Navigate -> _sideEffects.send(MainProfileSideEffect.Navigate(intent.navigationEvent))
+            is MainProfileIntent.Navigate -> navigationHelper.navigate(intent.navigationEvent)
             MainProfileIntent.OnValueTalkClick -> moveToValueTalkScreen()
             MainProfileIntent.OnBasicProfileClick -> moveToBasicProfileScreen()
             MainProfileIntent.OnValuePickClick -> moveToValuePickScreen()
         }
     }
 
-    private suspend fun moveToValuePickScreen() {
-        _sideEffects.send(
-            MainProfileSideEffect.Navigate(NavigationEvent.To(ProfileGraphDest.ValuePickProfileRoute))
-        )
+    private fun moveToValuePickScreen() {
+        navigationHelper.navigate(NavigationEvent.To(ProfileGraphDest.ValuePickProfileRoute))
     }
 
-    private suspend fun moveToBasicProfileScreen() {
-        _sideEffects.send(
-            MainProfileSideEffect.Navigate(NavigationEvent.To(ProfileGraphDest.BasicProfileRoute))
-        )
+    private fun moveToBasicProfileScreen() {
+        navigationHelper.navigate(NavigationEvent.To(ProfileGraphDest.BasicProfileRoute))
     }
 
-    private suspend fun moveToValueTalkScreen() {
-        _sideEffects.send(
-            MainProfileSideEffect.Navigate(NavigationEvent.To(ProfileGraphDest.ValueTalkProfileRoute))
-        )
+    private fun moveToValueTalkScreen() {
+        navigationHelper.navigate(NavigationEvent.To(ProfileGraphDest.ValueTalkProfileRoute))
     }
 
     @AssistedFactory

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/main/contract/MainProfileSideEffect.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/main/contract/MainProfileSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.profile.graph.main.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class MainProfileSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : MainProfileSideEffect()
-}

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/register/RegisterProfileScreen.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/register/RegisterProfileScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -23,13 +22,11 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.puzzle.common.ui.ANIMATION_DURATION
 import com.puzzle.common.ui.addFocusCleaner
 import com.puzzle.common.ui.blur
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceDialog
 import com.puzzle.designsystem.component.PieceDialogBottom
@@ -44,7 +41,6 @@ import com.puzzle.profile.graph.register.bottomsheet.ContactBottomSheet
 import com.puzzle.profile.graph.register.bottomsheet.JobBottomSheet
 import com.puzzle.profile.graph.register.bottomsheet.LocationBottomSheet
 import com.puzzle.profile.graph.register.contract.RegisterProfileIntent
-import com.puzzle.profile.graph.register.contract.RegisterProfileSideEffect
 import com.puzzle.profile.graph.register.contract.RegisterProfileState
 import com.puzzle.profile.graph.register.model.ValuePickRegisterRO
 import com.puzzle.profile.graph.register.model.ValueTalkRegisterRO
@@ -59,18 +55,6 @@ internal fun RegisterProfileRoute(
     viewModel: RegisterProfileViewModel = mavericksViewModel()
 ) {
     val state by viewModel.collectAsState()
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is RegisterProfileSideEffect.Navigate -> viewModel.navigationHelper
-                        .navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
 
     RegisterProfileScreen(
         state = state,

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/register/RegisterProfileScreen.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/register/RegisterProfileScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,6 +21,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -141,6 +146,7 @@ internal fun RegisterProfileRoute(
     )
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun RegisterProfileScreen(
     state: RegisterProfileState,
@@ -166,6 +172,9 @@ private fun RegisterProfileScreen(
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
+    val keyboardHeight = WindowInsets.ime.getBottom(LocalDensity.current)
+    val isImeVisible = WindowInsets.isImeVisible
+
     var valueTalks: List<ValueTalkRegisterRO> by remember(state.valueTalks) { mutableStateOf(state.valueTalks) }
     var valuePicks: List<ValuePickRegisterRO> by remember(state.valuePicks) { mutableStateOf(state.valuePicks) }
     var showDialog by remember { mutableStateOf(false) }
@@ -201,6 +210,7 @@ private fun RegisterProfileScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .graphicsLayer { if (isImeVisible) translationY = -keyboardHeight.toFloat() }
             .addFocusCleaner(focusManager)
             .blur(isBlur = showDialog),
     ) {
@@ -226,59 +236,57 @@ private fun RegisterProfileScreen(
             )
         }
 
-        Box(modifier = Modifier.weight(1f)) {
-            AnimatedContent(
-                targetState = state.currentPage,
-                transitionSpec = {
-                    fadeIn(tween(ANIMATION_DURATION)) togetherWith fadeOut(tween(ANIMATION_DURATION))
-                },
-                modifier = Modifier.fillMaxSize(),
-                label = "",
-            ) {
-                when (it) {
-                    RegisterProfileState.Page.BASIC_PROFILE -> BasicProfilePage(
-                        state = state,
-                        onProfileImageChanged = onProfileImageChanged,
-                        onNickNameChanged = onNickNameChanged,
-                        onDescribeMySelfChanged = onDescribeMySelfChanged,
-                        onBirthdateChanged = onBirthdateChanged,
-                        onLocationDropDownClicked = onLocationDropDownClicked,
-                        onHeightChanged = onHeightChanged,
-                        onWeightChanged = onWeightChanged,
-                        onJobDropDownClicked = onJobDropDownClicked,
-                        onSmokingStatusChanged = onSmokingStatusChanged,
-                        onSnsActivityChanged = onSnsActivityChanged,
-                        onDuplicationCheckClick = onDuplicationCheckClick,
-                        onContactChange = onContactChange,
-                        onSnsPlatformChange = onSnsPlatformChange,
-                        onAddContactClick = onAddContactClick,
-                        onDeleteClick = onDeleteContactClick,
-                    )
+        AnimatedContent(
+            targetState = state.currentPage,
+            transitionSpec = {
+                fadeIn(tween(ANIMATION_DURATION)) togetherWith fadeOut(tween(ANIMATION_DURATION))
+            },
+            modifier = Modifier.weight(1f),
+            label = "",
+        ) {
+            when (it) {
+                RegisterProfileState.Page.BASIC_PROFILE -> BasicProfilePage(
+                    state = state,
+                    onProfileImageChanged = onProfileImageChanged,
+                    onNickNameChanged = onNickNameChanged,
+                    onDescribeMySelfChanged = onDescribeMySelfChanged,
+                    onBirthdateChanged = onBirthdateChanged,
+                    onLocationDropDownClicked = onLocationDropDownClicked,
+                    onHeightChanged = onHeightChanged,
+                    onWeightChanged = onWeightChanged,
+                    onJobDropDownClicked = onJobDropDownClicked,
+                    onSmokingStatusChanged = onSmokingStatusChanged,
+                    onSnsActivityChanged = onSnsActivityChanged,
+                    onDuplicationCheckClick = onDuplicationCheckClick,
+                    onContactChange = onContactChange,
+                    onSnsPlatformChange = onSnsPlatformChange,
+                    onAddContactClick = onAddContactClick,
+                    onDeleteClick = onDeleteContactClick,
+                )
 
-                    RegisterProfileState.Page.VALUE_TALK -> ValueTalkPage(
-                        valueTalks = valueTalks,
-                        onValueTalkContentChange = { updatedValueTalks ->
-                            valueTalks = updatedValueTalks
-                        },
-                    )
+                RegisterProfileState.Page.VALUE_TALK -> ValueTalkPage(
+                    valueTalks = valueTalks,
+                    onValueTalkContentChange = { updatedValueTalks ->
+                        valueTalks = updatedValueTalks
+                    },
+                )
 
-                    RegisterProfileState.Page.VALUE_PICK -> ValuePickPage(
-                        valuePicks = valuePicks,
-                        onValuePickContentChange = { updatedValuePicks ->
-                            valuePicks = updatedValuePicks
-                        },
-                    )
+                RegisterProfileState.Page.VALUE_PICK -> ValuePickPage(
+                    valuePicks = valuePicks,
+                    onValuePickContentChange = { updatedValuePicks ->
+                        valuePicks = updatedValuePicks
+                    },
+                )
 
-                    RegisterProfileState.Page.SUMMATION -> SummationPage()
-                    RegisterProfileState.Page.FINISH -> FinishPage(
-                        userRole = state.userRole,
-                        onHomeClick = onHomeClick
-                    )
-                }
+                RegisterProfileState.Page.SUMMATION -> SummationPage()
+                RegisterProfileState.Page.FINISH -> FinishPage(
+                    userRole = state.userRole,
+                    onHomeClick = onHomeClick
+                )
             }
         }
 
-        if (state.currentPage != RegisterProfileState.Page.SUMMATION) {
+        if (!isImeVisible && state.currentPage != RegisterProfileState.Page.SUMMATION) {
             PieceSolidButton(
                 label = when (state.currentPage) {
                     RegisterProfileState.Page.FINISH -> stringResource(R.string.check_my_profile)

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/register/RegisterProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/register/RegisterProfileViewModel.kt
@@ -30,8 +30,6 @@ import com.puzzle.profile.graph.basic.contract.InputState.Companion.getInputStat
 import com.puzzle.profile.graph.basic.contract.InputState.Companion.getWeightInputState
 import com.puzzle.profile.graph.basic.contract.NickNameGuideMessage
 import com.puzzle.profile.graph.register.contract.RegisterProfileIntent
-import com.puzzle.profile.graph.register.contract.RegisterProfileSideEffect
-import com.puzzle.profile.graph.register.contract.RegisterProfileSideEffect.Navigate
 import com.puzzle.profile.graph.register.contract.RegisterProfileState
 import com.puzzle.profile.graph.register.model.ValuePickRegisterRO
 import com.puzzle.profile.graph.register.model.ValueTalkRegisterRO
@@ -59,8 +57,6 @@ class RegisterProfileViewModel @AssistedInject constructor(
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<RegisterProfileState>(initialState) {
     private val intents = Channel<RegisterProfileIntent>(BUFFERED)
-    private val _sideEffects = Channel<RegisterProfileSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         initProfileData()
@@ -223,7 +219,7 @@ class RegisterProfileViewModel @AssistedInject constructor(
     private fun moveToPrevious() {
         withState { state ->
             if (state.currentPage == RegisterProfileState.Page.BASIC_PROFILE) {
-                viewModelScope.launch { _sideEffects.send(Navigate(NavigationEvent.Up)) }
+                viewModelScope.launch { navigationHelper.navigate(NavigationEvent.Up) }
             } else {
                 state.currentPage.getPreviousPage()
                     ?.let { previousPage -> setState { copy(currentPage = previousPage) } }
@@ -250,8 +246,8 @@ class RegisterProfileViewModel @AssistedInject constructor(
         }
     }
 
-    private fun navigateToProfilePreview() = viewModelScope.launch {
-        _sideEffects.send(Navigate(NavigationEvent.TopLevelTo(MatchingGraphDest.ProfilePreviewRoute)))
+    private fun navigateToProfilePreview() {
+        navigationHelper.navigate(NavigationEvent.TopLevelTo(MatchingGraphDest.ProfilePreviewRoute))
     }
 
     private fun saveValuePick(state: RegisterProfileState) {

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/register/contract/RegisterProfileSideEffect.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/register/contract/RegisterProfileSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.profile.graph.register.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class RegisterProfileSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : RegisterProfileSideEffect()
-}

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/register/page/BasicProfilePage.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/register/page/BasicProfilePage.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.isDigitsOnly
 import coil3.compose.AsyncImage
+import com.puzzle.common.ui.addFocusCleaner
 import com.puzzle.common.ui.clickable
 import com.puzzle.common.ui.throttledClickable
 import com.puzzle.designsystem.R
@@ -78,14 +79,14 @@ internal fun BasicProfilePage(
     onDeleteClick: (Int) -> Unit,
     onAddContactClick: () -> Unit,
 ) {
-    val scrollState = rememberScrollState()
     val focusManager = LocalFocusManager.current
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = Modifier
             .padding(horizontal = 20.dp)
             .verticalScroll(scrollState)
-            .clickable { focusManager.clearFocus() },
+            .addFocusCleaner(focusManager)
     ) {
         Text(
             text = stringResource(R.string.basic_profile_page_header),
@@ -794,7 +795,6 @@ private fun PhotoContent(
     modifier: Modifier = Modifier,
     profileImageUri: String? = null,
 ) {
-    // TODO : 이미지 조건 추가, screenState == BasicProfileState.ScreenState.SAVE_FAILED && 이미지가 없을 경우
     val isSaveFailed: Boolean =
         profileImageUriInputState == InputState.WARNIING && profileImageUri == null
 

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/register/page/ValuePickPage.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/register/page/ValuePickPage.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -67,7 +68,12 @@ private fun ValuePickCards(
     onContentChange: (ValuePickRegisterRO) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(modifier = modifier.fillMaxSize()) {
+    val scrollState = rememberLazyListState()
+
+    LazyColumn(
+        state = scrollState,
+        modifier = modifier.fillMaxSize(),
+    ) {
         item {
             Text(
                 text = stringResource(R.string.value_pick_profile_page_header),

--- a/feature/profile/src/main/java/com/puzzle/profile/graph/register/page/ValueTalkPage.kt
+++ b/feature/profile/src/main/java/com/puzzle/profile/graph/register/page/ValueTalkPage.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -72,7 +73,12 @@ private fun ValueTalkCards(
     onContentChange: (ValueTalkRegisterRO) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(modifier = modifier.fillMaxSize()) {
+    val scrollState = rememberLazyListState()
+
+    LazyColumn(
+        state = scrollState,
+        modifier = modifier.fillMaxSize(),
+    ) {
         item {
             Text(
                 text = stringResource(R.string.value_talk_profile_page_header),

--- a/feature/setting/src/main/java/com/puzzle/setting/graph/main/SettingViewModel.kt
+++ b/feature/setting/src/main/java/com/puzzle/setting/graph/main/SettingViewModel.kt
@@ -17,7 +17,6 @@ import com.puzzle.navigation.NavigationHelper
 import com.puzzle.navigation.SettingGraphDest
 import com.puzzle.setting.BuildConfig
 import com.puzzle.setting.graph.main.contract.SettingIntent
-import com.puzzle.setting.graph.main.contract.SettingSideEffect
 import com.puzzle.setting.graph.main.contract.SettingState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -39,9 +38,6 @@ class SettingViewModel @AssistedInject constructor(
     internal val errorHelper: ErrorHelper,
 ) : MavericksViewModel<SettingState>(initialState) {
     private val _intents = Channel<SettingIntent>(BUFFERED)
-
-    private val _sideEffects = Channel<SettingSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         initSetting()

--- a/feature/setting/src/main/java/com/puzzle/setting/graph/main/contract/SettingSideEffect.kt
+++ b/feature/setting/src/main/java/com/puzzle/setting/graph/main/contract/SettingSideEffect.kt
@@ -1,3 +1,0 @@
-package com.puzzle.setting.graph.main.contract
-
-sealed class SettingSideEffect

--- a/feature/setting/src/main/java/com/puzzle/setting/graph/withdraw/WithdrawScreen.kt
+++ b/feature/setting/src/main/java/com/puzzle/setting/graph/withdraw/WithdrawScreen.kt
@@ -13,24 +13,20 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.puzzle.common.ui.ANIMATION_DURATION
 import com.puzzle.common.ui.addFocusCleaner
-import com.puzzle.common.ui.repeatOnStarted
 import com.puzzle.designsystem.R
 import com.puzzle.designsystem.component.PieceSubBackTopBar
 import com.puzzle.designsystem.foundation.PieceTheme
 import com.puzzle.setting.graph.withdraw.contract.WithdrawIntent
-import com.puzzle.setting.graph.withdraw.contract.WithdrawSideEffect
 import com.puzzle.setting.graph.withdraw.contract.WithdrawState
 import com.puzzle.setting.graph.withdraw.page.ConfirmPage
 import com.puzzle.setting.graph.withdraw.page.ReasonPage
@@ -40,34 +36,14 @@ internal fun WithdrawRoute(
     viewModel: WithdrawViewModel = mavericksViewModel(),
 ) {
     val state by viewModel.collectAsState()
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    LaunchedEffect(viewModel) {
-        lifecycleOwner.repeatOnStarted {
-            viewModel.sideEffects.collect { sideEffect ->
-                when (sideEffect) {
-                    is WithdrawSideEffect.Navigate -> viewModel.navigationHelper
-                        .navigate(sideEffect.navigationEvent)
-                }
-            }
-        }
-    }
 
     WithdrawScreen(
         state = state,
-        onReasonsClick = {
-            viewModel.onIntent(WithdrawIntent.OnReasonsClick(it))
-        },
+        onReasonsClick = { viewModel.onIntent(WithdrawIntent.OnReasonsClick(it)) },
         updateReason = { viewModel.onIntent(WithdrawIntent.UpdateReason(it)) },
-        onWithdrawClick = {
-            viewModel.onIntent(WithdrawIntent.OnWithdrawClick)
-        },
-        onNextClick = {
-            viewModel.onIntent(WithdrawIntent.OnNextClick)
-        },
-        onBackClick = {
-            viewModel.onIntent(WithdrawIntent.onBackClick)
-        },
+        onWithdrawClick = { viewModel.onIntent(WithdrawIntent.OnWithdrawClick) },
+        onNextClick = { viewModel.onIntent(WithdrawIntent.OnNextClick) },
+        onBackClick = { viewModel.onIntent(WithdrawIntent.onBackClick) },
     )
 }
 

--- a/feature/setting/src/main/java/com/puzzle/setting/graph/withdraw/WithdrawViewModel.kt
+++ b/feature/setting/src/main/java/com/puzzle/setting/graph/withdraw/WithdrawViewModel.kt
@@ -10,7 +10,6 @@ import com.puzzle.navigation.AuthGraph
 import com.puzzle.navigation.NavigationEvent
 import com.puzzle.navigation.NavigationHelper
 import com.puzzle.setting.graph.withdraw.contract.WithdrawIntent
-import com.puzzle.setting.graph.withdraw.contract.WithdrawSideEffect
 import com.puzzle.setting.graph.withdraw.contract.WithdrawState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -29,9 +28,6 @@ class WithdrawViewModel @AssistedInject constructor(
     private val errorHelper: ErrorHelper,
 ) : MavericksViewModel<WithdrawState>(initialState) {
     private val _intents = Channel<WithdrawIntent>(BUFFERED)
-
-    private val _sideEffects = Channel<WithdrawSideEffect>(BUFFERED)
-    val sideEffects = _sideEffects.receiveAsFlow()
 
     init {
         _intents.receiveAsFlow()
@@ -58,7 +54,7 @@ class WithdrawViewModel @AssistedInject constructor(
     }
 
     private suspend fun moveToPreviousScreen() {
-        _sideEffects.send(WithdrawSideEffect.Navigate(NavigationEvent.Up))
+        navigationHelper.navigate(NavigationEvent.Up)
     }
 
     private fun moveToWithdrawPage() {
@@ -75,11 +71,8 @@ class WithdrawViewModel @AssistedInject constructor(
             }
 
             authRepository.withdraw(reason)
-                .onSuccess {
-                    _sideEffects.send(
-                        WithdrawSideEffect.Navigate(NavigationEvent.TopLevelTo(AuthGraph))
-                    )
-                }.onFailure { errorHelper.sendError(it) }
+                .onSuccess { navigationHelper.navigate(NavigationEvent.TopLevelTo(AuthGraph)) }
+                .onFailure { errorHelper.sendError(it) }
         }
     }
 

--- a/feature/setting/src/main/java/com/puzzle/setting/graph/withdraw/contract/WithdrawSideEffect.kt
+++ b/feature/setting/src/main/java/com/puzzle/setting/graph/withdraw/contract/WithdrawSideEffect.kt
@@ -1,7 +1,0 @@
-package com.puzzle.setting.graph.withdraw.contract
-
-import com.puzzle.navigation.NavigationEvent
-
-sealed class WithdrawSideEffect {
-    data class Navigate(val navigationEvent: NavigationEvent) : WithdrawSideEffect()
-}

--- a/presentation/src/main/java/com/puzzle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/puzzle/presentation/MainActivity.kt
@@ -118,7 +118,7 @@ class MainActivity : ComponentActivity() {
                             App(
                                 snackBarHostState = snackBarHostState,
                                 navController = navController,
-                                navigateToBottomNaviNaviateTo = { bottomNaviDestination ->
+                                navigateToBottomNaviDestination = { bottomNaviDestination ->
                                     if (bottomNaviDestination == ProfileGraphDest.MainProfileRoute &&
                                         userRole != UserRole.USER
                                     ) {

--- a/presentation/src/main/java/com/puzzle/presentation/MainViewModel.kt
+++ b/presentation/src/main/java/com/puzzle/presentation/MainViewModel.kt
@@ -144,14 +144,11 @@ class MainViewModel @Inject constructor(
         val userRole = userRepository.getUserRole().first()
         when (userRole) {
             REGISTER ->
-                navigationHelper.navigate(To(route = AuthGraphDest.SignUpRoute, popUpTo = true))
+                navigationHelper.navigate(To(route = AuthGraphDest.SignUpRoute))
 
-            PENDING, USER ->
-                navigationHelper.navigate(
-                    To(route = MatchingGraphDest.MatchingRoute, popUpTo = true)
-                )
+            PENDING, USER -> navigationHelper.navigate(TopLevelTo(route = MatchingGraphDest.MatchingRoute))
 
-            NONE -> navigationHelper.navigate(To(route = OnboardingRoute, popUpTo = true))
+            NONE -> navigationHelper.navigate(TopLevelTo(route = OnboardingRoute))
         }
     }.also { _isInitialized.value = true }
 }

--- a/presentation/src/main/java/com/puzzle/presentation/ui/App.kt
+++ b/presentation/src/main/java/com/puzzle/presentation/ui/App.kt
@@ -71,7 +71,7 @@ import kotlin.reflect.KClass
 fun App(
     snackBarHostState: SnackbarHostState,
     navController: NavHostController,
-    navigateToBottomNaviNaviateTo: (Route) -> Unit,
+    navigateToBottomNaviDestination: (Route) -> Unit,
 ) {
     val currentDestination = navController.currentBackStackEntryAsState()
         .value?.destination
@@ -92,7 +92,7 @@ fun App(
             ) {
                 AppBottomBar(
                     currentDestination = currentDestination,
-                    navigateToTopLevelDestination = navigateToBottomNaviNaviateTo,
+                    navigateToBottomNaviDestination = navigateToBottomNaviDestination,
                 )
             }
         },
@@ -103,7 +103,7 @@ fun App(
                 exit = fadeOut() + slideOutVertically(),
             ) {
                 FloatingActionButton(
-                    onClick = { navigateToBottomNaviNaviateTo(MatchingGraph) },
+                    onClick = { navigateToBottomNaviDestination(MatchingGraph) },
                     containerColor = PieceTheme.colors.white,
                     shape = CircleShape,
                     elevation = bottomAppBarFabElevation(),
@@ -148,7 +148,7 @@ fun App(
 @Composable
 private fun AppBottomBar(
     currentDestination: NavDestination?,
-    navigateToTopLevelDestination: (Route) -> Unit,
+    navigateToBottomNaviDestination: (Route) -> Unit,
 ) {
     NavigationBar(
         containerColor = PieceTheme.colors.white,
@@ -189,12 +189,12 @@ private fun AppBottomBar(
                 interactionSource = remember { NoRippleInteractionSource() },
                 onClick = {
                     when (topLevelRoute) {
-                        TopLevelDestination.MATCHING -> navigateToTopLevelDestination(MatchingGraph)
-                        TopLevelDestination.PROFILE -> navigateToTopLevelDestination(
+                        TopLevelDestination.MATCHING -> navigateToBottomNaviDestination(MatchingGraph)
+                        TopLevelDestination.PROFILE -> navigateToBottomNaviDestination(
                             MainProfileRoute
                         )
 
-                        TopLevelDestination.SETTING -> navigateToTopLevelDestination(SettingGraph)
+                        TopLevelDestination.SETTING -> navigateToBottomNaviDestination(SettingGraph)
                     }
                 },
             )

--- a/presentation/src/main/java/com/puzzle/presentation/ui/App.kt
+++ b/presentation/src/main/java/com/puzzle/presentation/ui/App.kt
@@ -3,13 +3,14 @@
 package com.puzzle.presentation.ui
 
 import android.app.Activity
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -85,35 +86,48 @@ fun App(
         },
         containerColor = PieceTheme.colors.white,
         bottomBar = {
-            AnimatedVisibility(
-                visible = currentDestination?.shouldHideBottomNavigation() == false,
-                enter = fadeIn() + slideInVertically(),
-                exit = fadeOut() + slideOutVertically(),
-            ) {
-                AppBottomBar(
-                    currentDestination = currentDestination,
-                    navigateToBottomNaviDestination = navigateToBottomNaviDestination,
-                )
+            AnimatedContent(
+                targetState = currentDestination?.shouldHideBottomNavigation() == false,
+                transitionSpec = {
+                    fadeIn(tween(ANIMATION_DURATION)) +
+                            slideInVertically(tween(ANIMATION_DURATION)) togetherWith
+                            fadeOut(tween(ANIMATION_DURATION)) +
+                            slideOutVertically(tween(ANIMATION_DURATION))
+                },
+                modifier = Modifier.navigationBarsPadding(),
+            ) { isVisible ->
+                if (isVisible) {
+                    AppBottomBar(
+                        currentDestination = currentDestination,
+                        navigateToBottomNaviDestination = navigateToBottomNaviDestination,
+                    )
+                }
             }
         },
         floatingActionButton = {
-            AnimatedVisibility(
-                visible = currentDestination?.shouldHideBottomNavigation() == false,
-                enter = fadeIn() + slideInVertically(),
-                exit = fadeOut() + slideOutVertically(),
-            ) {
-                FloatingActionButton(
-                    onClick = { navigateToBottomNaviDestination(MatchingGraph) },
-                    containerColor = PieceTheme.colors.white,
-                    shape = CircleShape,
-                    elevation = bottomAppBarFabElevation(),
-                    modifier = Modifier.offset(y = 84.dp),
-                ) {
-                    Image(
-                        painter = painterResource(R.drawable.ic_matching),
-                        contentDescription = null,
-                        modifier = Modifier.size(80.dp),
-                    )
+            AnimatedContent(
+                targetState = currentDestination?.shouldHideBottomNavigation() == false,
+                transitionSpec = {
+                    fadeIn(tween(ANIMATION_DURATION)) +
+                            slideInVertically(tween(ANIMATION_DURATION)) togetherWith
+                            fadeOut(tween(ANIMATION_DURATION)) +
+                            slideOutVertically(tween(ANIMATION_DURATION))
+                },
+            ) { isVisible ->
+                if (isVisible) {
+                    FloatingActionButton(
+                        onClick = { navigateToBottomNaviDestination(MatchingGraph) },
+                        containerColor = PieceTheme.colors.white,
+                        shape = CircleShape,
+                        elevation = bottomAppBarFabElevation(),
+                        modifier = Modifier.offset(y = 84.dp),
+                    ) {
+                        Image(
+                            painter = painterResource(R.drawable.ic_matching),
+                            contentDescription = null,
+                            modifier = Modifier.size(80.dp),
+                        )
+                    }
                 }
             }
         },
@@ -152,9 +166,7 @@ private fun AppBottomBar(
 ) {
     NavigationBar(
         containerColor = PieceTheme.colors.white,
-        modifier = Modifier
-            .navigationBarsPadding()
-            .height(68.dp),
+        modifier = Modifier.height(68.dp),
     ) {
         TopLevelDestination.topLevelDestinations.forEach { topLevelRoute ->
             NavigationBarItem(
@@ -189,7 +201,10 @@ private fun AppBottomBar(
                 interactionSource = remember { NoRippleInteractionSource() },
                 onClick = {
                     when (topLevelRoute) {
-                        TopLevelDestination.MATCHING -> navigateToBottomNaviDestination(MatchingGraph)
+                        TopLevelDestination.MATCHING -> navigateToBottomNaviDestination(
+                            MatchingGraph
+                        )
+
                         TopLevelDestination.PROFILE -> navigateToBottomNaviDestination(
                             MainProfileRoute
                         )


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- **필요한 보일러 플레이트 SideEffects 제거**
- **네비게이션 애니메이션 점프 하던 UI 수정**

MVI의 SideEffect의 기능을 `navigationHelper`와 `eventHelper`로 모두 수행할 수 있기 때문에 보일러 플레이트 코드를 싹 걷었습니다.

LoginViewModel에 있는 Kakao와 Google Login은 SideEffect로 처리해야하기 때문에 이 녀석만 남아있습니다~


https://github.com/user-attachments/assets/c208be1e-6f8b-46cf-be9f-353119d58d0c


